### PR TITLE
Ensure the next 13 new-image-experimental codemod works with the TSX AST structures

### DIFF
--- a/codemods/jscodeshift/cloudinary-loader.js
+++ b/codemods/jscodeshift/cloudinary-loader.js
@@ -1,0 +1,6 @@
+const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src
+export default function cloudinaryLoader({ src, width, quality }) {
+const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
+const paramsString = params.join(',') + '/'
+return 'https://example.com/' + paramsString + normalizeSrc(src)
+}

--- a/codemods/jscodeshift/cloudinary-loader.js
+++ b/codemods/jscodeshift/cloudinary-loader.js
@@ -1,6 +1,0 @@
-const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src
-export default function cloudinaryLoader({ src, width, quality }) {
-const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
-const paramsString = params.join(',') + '/'
-return 'https://example.com/' + paramsString + normalizeSrc(src)
-}

--- a/codemods/jscodeshift/mochaHooks.ts
+++ b/codemods/jscodeshift/mochaHooks.ts
@@ -1,9 +1,9 @@
 import jscodeshift, { API } from 'jscodeshift';
 import type { RootHookObject, Context } from 'mocha';
 
-const buildApi = (parser: string): API => ({
-	j: jscodeshift.withParser(parser),
-	jscodeshift: jscodeshift.withParser(parser),
+const buildApi = (parser: string | undefined): API => ({
+	j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+	jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
 	stats: () => {
 		console.error(
 			'The stats function was called, which is not supported on purpose',

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -244,13 +244,9 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 					})
 					.paths(),
 			)
-			.map((objectPropertyPath) => {
-				console.log(
-					j(objectPropertyPath).find(j.StringLiteral).paths(),
-				);
-
-				return j(objectPropertyPath).find(j.StringLiteral).paths();
-			})
+			.map((objectPropertyPath) =>
+				j(objectPropertyPath).find(j.StringLiteral).paths(),
+			)
 			.filter((_, i) => i === 0);
 
 		const loaderType = loaderTypeStringLiteralsPaths.nodes()[0]?.value;

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -201,101 +201,114 @@ function findAndReplaceProps(
 }
 
 function nextConfigTransformer(j: JSCodeshift, root: Collection) {
-	let pathPrefix = '';
-	let loaderType = '';
 	root.find(j.ObjectExpression).forEach((o) => {
-		const [images] = o.value.properties || [];
-		if (
-			images &&
-			images.type === 'Property' &&
-			images.key.type === 'Identifier' &&
-			images.key.name === 'images' &&
-			images.value.type === 'ObjectExpression' &&
-			images.value.properties
-		) {
-			const properties = images.value.properties.filter((p) => {
+		const [images] = o.value.properties;
+
+		if (!images) {
+			return;
+		}
+
+		if (images.type !== 'ObjectProperty') {
+			return;
+		}
+
+		const { key, value } = images;
+
+		if (key.type !== 'Identifier' || key.name !== 'images') {
+			return;
+		}
+
+		if (value.type !== 'ObjectExpression') {
+			return;
+		}
+
+		let pathPrefix = '';
+		let loaderType = '';
+
+		const properties = value.properties.filter((p) => {
+			if (
+				p.type === 'ObjectProperty' &&
+				p.key.type === 'Identifier' &&
+				p.key.name === 'loader' &&
+				'value' in p.value
+			) {
 				if (
-					p.type === 'Property' &&
-					p.key.type === 'Identifier' &&
-					p.key.name === 'loader' &&
-					'value' in p.value
+					p.value.value === 'imgix' ||
+					p.value.value === 'cloudinary' ||
+					p.value.value === 'akamai'
 				) {
-					if (
-						p.value.value === 'imgix' ||
-						p.value.value === 'cloudinary' ||
-						p.value.value === 'akamai'
-					) {
-						loaderType = p.value.value;
-						p.value.value = 'custom';
-					}
+					loaderType = p.value.value;
+					p.value.value = 'custom';
 				}
-				if (
-					p.type === 'Property' &&
-					p.key.type === 'Identifier' &&
-					p.key.name === 'path' &&
-					'value' in p.value
-				) {
-					pathPrefix = String(p.value.value);
-					return false;
-				}
-				return true;
-			});
-			if (loaderType && pathPrefix) {
-				let filename = `./${loaderType}-loader.js`;
-				properties.push(
-					j.property(
-						'init',
-						j.identifier('loaderFile'),
-						j.literal(filename),
-					),
+			}
+			if (
+				p.type === 'ObjectProperty' &&
+				p.key.type === 'Identifier' &&
+				p.key.name === 'path' &&
+				'value' in p.value
+			) {
+				pathPrefix = String(p.value.value);
+				return false;
+			}
+			return true;
+		});
+
+		if (loaderType && pathPrefix) {
+			let filename = `./${loaderType}-loader.js`;
+			properties.push(
+				j.property(
+					'init',
+					j.identifier('loaderFile'),
+					j.literal(filename),
+				),
+			);
+			value.properties = properties;
+			const normalizeSrc = `const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src`;
+			if (loaderType === 'imgix') {
+				writeFileSync(
+					filename,
+					`${normalizeSrc}
+	export default function imgixLoader({ src, width, quality }) {
+		const url = new URL('${pathPrefix}' + normalizeSrc(src))
+		const params = url.searchParams
+		params.set('auto', params.getAll('auto').join(',') || 'format')
+		params.set('fit', params.get('fit') || 'max')
+		params.set('w', params.get('w') || width.toString())
+		if (quality) { params.set('q', quality.toString()) }
+		return url.href
+	}`
+						.split('\n')
+						.map((l) => l.trim())
+						.join('\n'),
 				);
-				images.value.properties = properties;
-				const normalizeSrc = `const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src`;
-				if (loaderType === 'imgix') {
-					writeFileSync(
-						filename,
-						`${normalizeSrc}
-            export default function imgixLoader({ src, width, quality }) {
-              const url = new URL('${pathPrefix}' + normalizeSrc(src))
-              const params = url.searchParams
-              params.set('auto', params.getAll('auto').join(',') || 'format')
-              params.set('fit', params.get('fit') || 'max')
-              params.set('w', params.get('w') || width.toString())
-              if (quality) { params.set('q', quality.toString()) }
-              return url.href
-            }`
-							.split('\n')
-							.map((l) => l.trim())
-							.join('\n'),
-					);
-				} else if (loaderType === 'cloudinary') {
-					writeFileSync(
-						filename,
-						`${normalizeSrc}
-            export default function cloudinaryLoader({ src, width, quality }) {
-              const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
-              const paramsString = params.join(',') + '/'
-              return '${pathPrefix}' + paramsString + normalizeSrc(src)
-            }`
-							.split('\n')
-							.map((l) => l.trim())
-							.join('\n'),
-					);
-				} else if (loaderType === 'akamai') {
-					writeFileSync(
-						filename,
-						`${normalizeSrc}
-            export default function akamaiLoader({ src, width, quality }) {
-              return '${pathPrefix}' + normalizeSrc(src) + '?imwidth=' + width
-            }`
-							.split('\n')
-							.map((l) => l.trim())
-							.join('\n'),
-					);
-				}
+			} else if (loaderType === 'cloudinary') {
+				writeFileSync(
+					filename,
+					`${normalizeSrc}
+	export default function cloudinaryLoader({ src, width, quality }) {
+		const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
+		const paramsString = params.join(',') + '/'
+		return '${pathPrefix}' + paramsString + normalizeSrc(src)
+	}`
+						.split('\n')
+						.map((l) => l.trim())
+						.join('\n'),
+				);
+			} else if (loaderType === 'akamai') {
+				writeFileSync(
+					filename,
+					`${normalizeSrc}
+	export default function akamaiLoader({ src, width, quality }) {
+		return '${pathPrefix}' + normalizeSrc(src) + '?imwidth=' + width
+	}`
+						.split('\n')
+						.map((l) => l.trim())
+						.join('\n'),
+				);
 			}
 		}
 	});
+
 	return root;
 }
 

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -276,16 +276,25 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 			.forEach((objectPropertyPath) => {
 				j(objectPropertyPath)
 					.find(j.ObjectExpression)
-					.filter((_, i) => i === 0);
-				// .replaceWith((objectExpressionPath) => {
-				// 	return objectExpressionPath.value;
-				// });
-			});
+					.filter((_, i) => i === 0)
+					.replaceWith((objectExpressionPath) => {
+						const objectExpression = objectExpressionPath.value;
 
-		// properties.push(
-		// 	j.property('init', j.identifier('loaderFile'), j.literal(filename)),
-		// );
-		// value.properties = properties;
+						const properties = [
+							...objectExpression.properties,
+							j.property(
+								'init',
+								j.identifier('loaderFile'),
+								j.literal(filename),
+							),
+						];
+
+						return {
+							...objectExpression,
+							properties,
+						};
+					});
+			});
 
 		const normalizeSrc = `const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src`;
 		if (loaderType === 'imgix') {

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -201,112 +201,148 @@ function findAndReplaceProps(
 }
 
 function nextConfigTransformer(j: JSCodeshift, root: Collection) {
-	root.find(j.ObjectExpression).forEach((o) => {
-		const [images] = o.value.properties;
+	root.find(j.ObjectExpression).forEach((objectExpressionPath) => {
+		const values = ['imgix', 'cloudinary', 'akamai'];
 
-		if (!images) {
-			return;
-		}
-
-		if (images.type !== 'ObjectProperty') {
-			return;
-		}
-
-		const { key, value } = images;
-
-		if (key.type !== 'Identifier' || key.name !== 'images') {
-			return;
-		}
-
-		if (value.type !== 'ObjectExpression') {
-			return;
-		}
-
-		let pathPrefix = '';
-		let loaderType = '';
-
-		const properties = value.properties.filter((p) => {
-			if (
-				p.type === 'ObjectProperty' &&
-				p.key.type === 'Identifier' &&
-				p.key.name === 'loader' &&
-				'value' in p.value
-			) {
-				if (
-					p.value.value === 'imgix' ||
-					p.value.value === 'cloudinary' ||
-					p.value.value === 'akamai'
-				) {
-					loaderType = p.value.value;
-					p.value.value = 'custom';
-				}
-			}
-			if (
-				p.type === 'ObjectProperty' &&
-				p.key.type === 'Identifier' &&
-				p.key.name === 'path' &&
-				'value' in p.value
-			) {
-				pathPrefix = String(p.value.value);
-				return false;
-			}
-			return true;
-		});
-
-		if (loaderType && pathPrefix) {
-			let filename = `./${loaderType}-loader.js`;
-			properties.push(
-				j.property(
-					'init',
-					j.identifier('loaderFile'),
-					j.literal(filename),
-				),
+		const loaderTypeStringLiteralsPaths = j(objectExpressionPath)
+			.find(j.ObjectProperty, {
+				key: {
+					type: 'Identifier',
+					name: 'images',
+				},
+			})
+			.map((objectPropertyPath) =>
+				j(objectPropertyPath)
+					.find(j.ObjectProperty, {
+						key: {
+							type: 'Identifier',
+							name: 'loader',
+						},
+					})
+					.paths(),
+			)
+			.map((objectPropertyPath) =>
+				j(objectPropertyPath).find(j.StringLiteral).paths(),
+			)
+			.filter(
+				(stringLiteralPath, i) =>
+					i === 0 && values.includes(stringLiteralPath.value.value),
 			);
-			value.properties = properties;
-			const normalizeSrc = `const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src`;
-			if (loaderType === 'imgix') {
-				writeFileSync(
-					filename,
-					`${normalizeSrc}
-	export default function imgixLoader({ src, width, quality }) {
-		const url = new URL('${pathPrefix}' + normalizeSrc(src))
-		const params = url.searchParams
-		params.set('auto', params.getAll('auto').join(',') || 'format')
-		params.set('fit', params.get('fit') || 'max')
-		params.set('w', params.get('w') || width.toString())
-		if (quality) { params.set('q', quality.toString()) }
-		return url.href
-	}`
-						.split('\n')
-						.map((l) => l.trim())
-						.join('\n'),
-				);
-			} else if (loaderType === 'cloudinary') {
-				writeFileSync(
-					filename,
-					`${normalizeSrc}
-	export default function cloudinaryLoader({ src, width, quality }) {
-		const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
-		const paramsString = params.join(',') + '/'
-		return '${pathPrefix}' + paramsString + normalizeSrc(src)
-	}`
-						.split('\n')
-						.map((l) => l.trim())
-						.join('\n'),
-				);
-			} else if (loaderType === 'akamai') {
-				writeFileSync(
-					filename,
-					`${normalizeSrc}
-	export default function akamaiLoader({ src, width, quality }) {
-		return '${pathPrefix}' + normalizeSrc(src) + '?imwidth=' + width
-	}`
-						.split('\n')
-						.map((l) => l.trim())
-						.join('\n'),
-				);
-			}
-		}
+
+		let loaderType = loaderTypeStringLiteralsPaths
+			.nodes()
+			.map(({ value }) => value)[0];
+
+		console.log(loaderType);
+
+		// replacement
+		// loaderTypeStringLiteralsPaths.re((stringLiteral) => {});
+
+		// 	const [images] = objectExpressionPath.value.properties;
+
+		// 	if (!images) {
+		// 		return;
+		// 	}
+
+		// 	if (images.type !== 'ObjectProperty') {
+		// 		return;
+		// 	}
+
+		// 	const { key, value } = images;
+
+		// 	if (key.type !== 'Identifier' || key.name !== 'images') {
+		// 		return;
+		// 	}
+
+		// 	if (value.type !== 'ObjectExpression') {
+		// 		return;
+		// 	}
+
+		// 	let pathPrefix = '';
+		// 	let loaderType = '';
+
+		// 	const properties = value.properties.filter((p) => {
+		// 		if (
+		// 			p.type === 'ObjectProperty' &&
+		// 			p.key.type === 'Identifier' &&
+		// 			p.key.name === 'loader' &&
+		// 			'value' in p.value
+		// 		) {
+		// 			if (
+		// 				p.value.value === 'imgix' ||
+		// 				p.value.value === 'cloudinary' ||
+		// 				p.value.value === 'akamai'
+		// 			) {
+		// 				loaderType = p.value.value;
+		// 				p.value.value = 'custom';
+		// 			}
+		// 		}
+		// 		if (
+		// 			p.type === 'ObjectProperty' &&
+		// 			p.key.type === 'Identifier' &&
+		// 			p.key.name === 'path' &&
+		// 			'value' in p.value
+		// 		) {
+		// 			pathPrefix = String(p.value.value);
+		// 			return false;
+		// 		}
+		// 		return true;
+		// 	});
+
+		// 	if (loaderType && pathPrefix) {
+		// 		let filename = `./${loaderType}-loader.js`;
+		// 		properties.push(
+		// 			j.property(
+		// 				'init',
+		// 				j.identifier('loaderFile'),
+		// 				j.literal(filename),
+		// 			),
+		// 		);
+		// 		value.properties = properties;
+		// 		const normalizeSrc = `const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src`;
+		// 		if (loaderType === 'imgix') {
+		// 			writeFileSync(
+		// 				filename,
+		// 				`${normalizeSrc}
+		// export default function imgixLoader({ src, width, quality }) {
+		// 	const url = new URL('${pathPrefix}' + normalizeSrc(src))
+		// 	const params = url.searchParams
+		// 	params.set('auto', params.getAll('auto').join(',') || 'format')
+		// 	params.set('fit', params.get('fit') || 'max')
+		// 	params.set('w', params.get('w') || width.toString())
+		// 	if (quality) { params.set('q', quality.toString()) }
+		// 	return url.href
+		// }`
+		// 					.split('\n')
+		// 					.map((l) => l.trim())
+		// 					.join('\n'),
+		// 			);
+		// 		} else if (loaderType === 'cloudinary') {
+		// 			writeFileSync(
+		// 				filename,
+		// 				`${normalizeSrc}
+		// export default function cloudinaryLoader({ src, width, quality }) {
+		// 	const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
+		// 	const paramsString = params.join(',') + '/'
+		// 	return '${pathPrefix}' + paramsString + normalizeSrc(src)
+		// }`
+		// 					.split('\n')
+		// 					.map((l) => l.trim())
+		// 					.join('\n'),
+		// 			);
+		// 		} else if (loaderType === 'akamai') {
+		// 			writeFileSync(
+		// 				filename,
+		// 				`${normalizeSrc}
+		// export default function akamaiLoader({ src, width, quality }) {
+		// 	return '${pathPrefix}' + normalizeSrc(src) + '?imwidth=' + width
+		// }`
+		// 					.split('\n')
+		// 					.map((l) => l.trim())
+		// 					.join('\n'),
+		// 			);
+		// 		}
+		// 	}
 	});
 
 	return root;

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -202,7 +202,7 @@ function findAndReplaceProps(
 
 function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 	root.find(j.ObjectExpression).forEach((objectExpressionPath) => {
-		const values = ['imgix', 'cloudinary', 'akamai'];
+		const LOADERS = ['imgix', 'cloudinary', 'akamai'];
 
 		const imagesObjectPropertyPaths = j(objectExpressionPath).find(
 			j.ObjectProperty,
@@ -230,7 +230,7 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 			)
 			.filter(
 				(stringLiteralPath, i) =>
-					i === 0 && values.includes(stringLiteralPath.value.value),
+					i === 0 && LOADERS.includes(stringLiteralPath.value.value),
 			);
 
 		const pathObjectPropertyPaths = imagesObjectPropertyPaths.map(
@@ -257,14 +257,13 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 			return;
 		}
 
-		// replacement
+		const filename = `./${loaderType}-loader.js`;
+
 		loaderTypeStringLiteralsPaths.replaceWith(() =>
 			j.stringLiteral('custom'),
 		);
 
 		pathObjectPropertyPaths.remove();
-
-		const filename = `./${loaderType}-loader.js`;
 
 		j(objectExpressionPath)
 			.find(j.ObjectProperty, {

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -261,9 +261,25 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 			j.stringLiteral('custom'),
 		);
 
-		pathTypeStringLiteralsPaths.remove();
+		// pathTypeStringLiteralsPaths.remove();
 
 		const filename = `./${loaderType}-loader.js`;
+
+		j(objectExpressionPath)
+			.find(j.ObjectProperty, {
+				key: {
+					type: 'Identifier',
+					name: 'images',
+				},
+			})
+			.forEach((objectPropertyPath) => {
+				j(objectPropertyPath)
+					.find(j.ObjectExpression)
+					.filter((_, i) => i === 0);
+				// .replaceWith((objectExpressionPath) => {
+				// 	return objectExpressionPath.value;
+				// });
+			});
 
 		// properties.push(
 		// 	j.property('init', j.identifier('loaderFile'), j.literal(filename)),

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -200,7 +200,11 @@ function findAndReplaceProps(
 		});
 }
 
-function nextConfigTransformer(j: JSCodeshift, root: Collection) {
+function nextConfigTransformer(
+	j: JSCodeshift,
+	root: Collection,
+	dryRun: boolean,
+) {
 	root.find(j.ObjectExpression).forEach((objectExpressionPath) => {
 		const LOADERS = ['imgix', 'cloudinary', 'akamai'];
 
@@ -296,7 +300,8 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 			});
 
 		const normalizeSrc = `const normalizeSrc = (src) => src[0] === '/' ? src.slice(1) : src`;
-		if (loaderType === 'imgix') {
+
+		if (loaderType === 'imgix' && !dryRun) {
 			writeFileSync(
 				filename,
 				`${normalizeSrc}
@@ -313,7 +318,7 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 					.map((l) => l.trim())
 					.join('\n'),
 			);
-		} else if (loaderType === 'cloudinary') {
+		} else if (loaderType === 'cloudinary' && !dryRun) {
 			writeFileSync(
 				filename,
 				`${normalizeSrc}
@@ -326,7 +331,7 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 					.map((l) => l.trim())
 					.join('\n'),
 			);
-		} else if (loaderType === 'akamai') {
+		} else if (loaderType === 'akamai' && !dryRun) {
 			writeFileSync(
 				filename,
 				`${normalizeSrc}
@@ -358,7 +363,11 @@ export default function transformer(
 		const j = api.jscodeshift.withParser('tsx');
 		const root = j(file.source);
 
-		return nextConfigTransformer(j, root).toSource();
+		return nextConfigTransformer(
+			j,
+			root,
+			Boolean(options.dryRun),
+		).toSource();
 	}
 
 	const j = api.jscodeshift;

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -229,14 +229,14 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 					i === 0 && values.includes(stringLiteralPath.value.value),
 			);
 
-		let loaderType = loaderTypeStringLiteralsPaths
-			.nodes()
-			.map(({ value }) => value)[0];
+		let loaderType = loaderTypeStringLiteralsPaths.nodes()[0]?.value;
 
 		console.log(loaderType);
 
 		// replacement
-		// loaderTypeStringLiteralsPaths.re((stringLiteral) => {});
+		loaderTypeStringLiteralsPaths.replaceWith(() =>
+			j.stringLiteral('custom'),
+		);
 
 		// 	const [images] = objectExpressionPath.value.properties;
 

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -204,13 +204,17 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 	root.find(j.ObjectExpression).forEach((objectExpressionPath) => {
 		const values = ['imgix', 'cloudinary', 'akamai'];
 
-		const loaderTypeStringLiteralsPaths = j(objectExpressionPath)
-			.find(j.ObjectProperty, {
+		const imagesObjectPropertyPaths = j(objectExpressionPath).find(
+			j.ObjectProperty,
+			{
 				key: {
 					type: 'Identifier',
 					name: 'images',
 				},
-			})
+			},
+		);
+
+		const loaderTypeStringLiteralsPaths = imagesObjectPropertyPaths
 			.map((objectPropertyPath) =>
 				j(objectPropertyPath)
 					.find(j.ObjectProperty, {
@@ -229,9 +233,29 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 					i === 0 && values.includes(stringLiteralPath.value.value),
 			);
 
-		let loaderType = loaderTypeStringLiteralsPaths.nodes()[0]?.value;
+		const pathTypeStringLiteralsPaths = imagesObjectPropertyPaths
+			.map((objectPropertyPath) =>
+				j(objectPropertyPath)
+					.find(j.ObjectProperty, {
+						key: {
+							type: 'Identifier',
+							name: 'path',
+						},
+					})
+					.paths(),
+			)
+			.map((objectPropertyPath) =>
+				j(objectPropertyPath).find(j.StringLiteral).paths(),
+			)
+			.filter(
+				(stringLiteralPath, i) =>
+					i === 0 && values.includes(stringLiteralPath.value.value),
+			);
 
-		console.log(loaderType);
+		const loaderType = loaderTypeStringLiteralsPaths.nodes()[0]?.value;
+		const pathPrefix = pathTypeStringLiteralsPaths.nodes()[0]?.value;
+
+		console.log(loaderType, pathPrefix);
 
 		// replacement
 		loaderTypeStringLiteralsPaths.replaceWith(() =>

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -233,8 +233,8 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 					i === 0 && values.includes(stringLiteralPath.value.value),
 			);
 
-		const pathTypeStringLiteralsPaths = imagesObjectPropertyPaths
-			.map((objectPropertyPath) =>
+		const pathObjectPropertyPaths = imagesObjectPropertyPaths.map(
+			(objectPropertyPath) =>
 				j(objectPropertyPath)
 					.find(j.ObjectProperty, {
 						key: {
@@ -243,14 +243,15 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 						},
 					})
 					.paths(),
-			)
+		);
+
+		const loaderType = loaderTypeStringLiteralsPaths.nodes()[0]?.value;
+		const pathPrefix = pathObjectPropertyPaths
 			.map((objectPropertyPath) =>
 				j(objectPropertyPath).find(j.StringLiteral).paths(),
 			)
-			.filter((_, i) => i === 0);
-
-		const loaderType = loaderTypeStringLiteralsPaths.nodes()[0]?.value;
-		const pathPrefix = pathTypeStringLiteralsPaths.nodes()[0]?.value;
+			.filter((_, i) => i === 0)
+			.nodes()[0]?.value;
 
 		if (!loaderType || !pathPrefix) {
 			return;
@@ -261,7 +262,7 @@ function nextConfigTransformer(j: JSCodeshift, root: Collection) {
 			j.stringLiteral('custom'),
 		);
 
-		// pathTypeStringLiteralsPaths.remove();
+		pathObjectPropertyPaths.remove();
 
 		const filename = `./${loaderType}-loader.js`;
 

--- a/codemods/jscodeshift/next/13/new-image-experimental/index.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/index.ts
@@ -348,9 +348,6 @@ export default function transformer(
 	api: API,
 	options: Options,
 ) {
-	const j = api.jscodeshift;
-	const root = j(file.source);
-
 	const isConfig =
 		file.path === 'next.config.js' ||
 		file.path === 'next.config.ts' ||
@@ -358,9 +355,14 @@ export default function transformer(
 		file.path === 'next.config.cjs';
 
 	if (isConfig) {
-		const result = nextConfigTransformer(j, root);
-		return result.toSource();
+		const j = api.jscodeshift.withParser('tsx');
+		const root = j(file.source);
+
+		return nextConfigTransformer(j, root).toSource();
 	}
+
+	const j = api.jscodeshift;
+	const root = j(file.source);
 
 	// Before: import Image from "next/legacy/image"
 	//  After: import Image from "next/image"

--- a/codemods/jscodeshift/next/13/new-image-experimental/test.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/test.ts
@@ -1,3 +1,31 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2023 Vercel, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+Changes to the original input and output variables that were incorporated from https://github.com/vercel/next.js/pull/45970: formatting
+*/
+
 import transform from '.';
 import { FileInfo } from 'jscodeshift';
 import assert from 'node:assert';

--- a/codemods/jscodeshift/next/13/new-image-experimental/test.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/test.ts
@@ -1,0 +1,47 @@
+import transform from '.';
+import { FileInfo } from 'jscodeshift';
+import assert from 'node:assert';
+
+describe.only('new-image-experimental', () => {
+	it('should add the State type for state parameter of the mapStateToProps and the mapDispatchToProps function', function () {
+		const INPUT = `
+		const withPwa = (opts) => {
+			// no-op but image this adds props
+			return opts
+		  }
+		  module.exports = withPwa({
+			images: {
+			  loader: "cloudinary",
+			  path: "https://example.com/",
+			},
+		  })
+        `;
+
+		const OUTPUT = `
+		const withPwa = (opts) => {
+			// no-op but image this adds props
+			return opts
+		  }
+		  module.exports = withPwa({
+			images: {
+			  loader: "custom",
+			  loaderFile: "./cloudinary-loader.js",
+			},
+		  })
+        `;
+
+		const fileInfo: FileInfo = {
+			path: 'next.config.ts',
+			source: INPUT,
+		};
+
+		const actualOutput = transform(fileInfo, this.buildApi('tsx'), {});
+
+		console.log(actualOutput);
+
+		assert.deepEqual(
+			actualOutput?.replace(/\W/gm, ''),
+			OUTPUT.replace(/\W/gm, ''),
+		);
+	});
+});

--- a/codemods/jscodeshift/next/13/new-image-experimental/test.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/test.ts
@@ -51,8 +51,6 @@ describe.only('new-image-experimental', () => {
 
 		const actualOutput = transform(fileInfo, this.buildApi(), {});
 
-		console.log(actualOutput);
-
 		assert.deepEqual(
 			actualOutput?.replace(/\W/gm, ''),
 			OUTPUT.replace(/\W/gm, ''),

--- a/codemods/jscodeshift/next/13/new-image-experimental/test.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/test.ts
@@ -2,7 +2,7 @@ import transform from '.';
 import { FileInfo } from 'jscodeshift';
 import assert from 'node:assert';
 
-describe.only('new-image-experimental', () => {
+describe('new-image-experimental', () => {
 	const INPUT = `
 		const withPwa = (opts) => {
 			// no-op but image this adds props

--- a/codemods/jscodeshift/next/13/new-image-experimental/test.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/test.ts
@@ -3,8 +3,7 @@ import { FileInfo } from 'jscodeshift';
 import assert from 'node:assert';
 
 describe.only('new-image-experimental', () => {
-	it('should add the State type for state parameter of the mapStateToProps and the mapDispatchToProps function', function () {
-		const INPUT = `
+	const INPUT = `
 		const withPwa = (opts) => {
 			// no-op but image this adds props
 			return opts
@@ -15,9 +14,9 @@ describe.only('new-image-experimental', () => {
 			  path: "https://example.com/",
 			},
 		  })
-        `;
+	`;
 
-		const OUTPUT = `
+	const OUTPUT = `
 		const withPwa = (opts) => {
 			// no-op but image this adds props
 			return opts
@@ -28,14 +27,29 @@ describe.only('new-image-experimental', () => {
 			  loaderFile: "./cloudinary-loader.js",
 			},
 		  })
-        `;
+	`;
 
+	it('should replace next.config.ts with the tsx parser', function () {
 		const fileInfo: FileInfo = {
 			path: 'next.config.ts',
 			source: INPUT,
 		};
 
 		const actualOutput = transform(fileInfo, this.buildApi('tsx'), {});
+
+		assert.deepEqual(
+			actualOutput?.replace(/\W/gm, ''),
+			OUTPUT.replace(/\W/gm, ''),
+		);
+	});
+
+	it('should replace next.config.ts with the recast parser', function () {
+		const fileInfo: FileInfo = {
+			path: 'next.config.ts',
+			source: INPUT,
+		};
+
+		const actualOutput = transform(fileInfo, this.buildApi(), {});
 
 		console.log(actualOutput);
 

--- a/codemods/jscodeshift/next/13/new-image-experimental/test.ts
+++ b/codemods/jscodeshift/next/13/new-image-experimental/test.ts
@@ -35,7 +35,9 @@ describe('new-image-experimental', () => {
 			source: INPUT,
 		};
 
-		const actualOutput = transform(fileInfo, this.buildApi('tsx'), {});
+		const actualOutput = transform(fileInfo, this.buildApi('tsx'), {
+			dryRun: true,
+		});
 
 		assert.deepEqual(
 			actualOutput?.replace(/\W/gm, ''),
@@ -49,7 +51,9 @@ describe('new-image-experimental', () => {
 			source: INPUT,
 		};
 
-		const actualOutput = transform(fileInfo, this.buildApi(), {});
+		const actualOutput = transform(fileInfo, this.buildApi(), {
+			dryRun: true,
+		});
 
 		assert.deepEqual(
 			actualOutput?.replace(/\W/gm, ''),

--- a/codemods/jscodeshift/react-redux/0/add-state-type/test.ts
+++ b/codemods/jscodeshift/react-redux/0/add-state-type/test.ts
@@ -2,7 +2,7 @@ import { FileInfo } from 'jscodeshift';
 import assert from 'node:assert';
 import transform from '.';
 
-describe.only('react-redux-8 add-state-type', function () {
+describe('react-redux-8 add-state-type', function () {
 	it('should add the State type for state parameter of the mapStateToProps arrow function', function () {
 		const INPUT = `
             const mapStateToProps = (state) => ({


### PR DESCRIPTION
Changes:
* parsing of the `next.config.*` file happens with a `tsx` parser (which is the `babylon` parser with TS and JSX parsing capabilities)
* passing `dryRun` in the codemod options disables file creation by the codemod
* refactor the config file rewrite so that:
  * node lookup is done using JSCodeshift/Recast collection and AST paths utilities (finding, filtering and mapping) instead of inspecting properties
  * node replacement and deletion does not happen silently by changing properties, instead we use `.rewriteWith` and `.remove` methods stemming from JSCodeShift API
* added tests for the codemod