### PR TITLE
Produce nullability checks in the next/router codemod

### DIFF
--- a/codemods/ts-morph/next/13/replace-next-router/index.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/index.ts
@@ -121,20 +121,6 @@ const handleRouterPropertyAccessExpression = (
 		onReplacedWithPathname();
 	} else if (nodeName === 'isFallback') {
 		node.replaceWithText('false');
-	} else if (nodeName === 'push') {
-		const parentNode = node.getParent();
-
-		if (Node.isCallExpression(parentNode)) {
-			const [firstArgument] = parentNode.getArguments();
-
-			if (Node.isObjectLiteralExpression(firstArgument)) {
-				const text = firstArgument.getFullText();
-
-				firstArgument.replaceWithText(`JSON.stringify(${text})`);
-			}
-		}
-
-		usesRouter.set(() => true);
 	} else {
 		// unrecognized node names
 		usesRouter.set(() => true);

--- a/codemods/ts-morph/next/13/replace-next-router/index.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/index.ts
@@ -437,6 +437,30 @@ const handleUseRouterCallExpression = (
 			return;
 		} else if (text === 'isFallback') {
 			parent.replaceWithText('false');
+		} else if (text === 'asPath') {
+			if (Node.isVariableDeclaration(grandparent)) {
+				const vdName = grandparent.getName();
+
+				grandparent.findReferencesAsNodes().forEach((reference) => {
+					console.log(reference.getText());
+
+					if (Node.isIdentifier(reference)) {
+						const parentNode = reference.getParent();
+
+						if (Node.isPropertyAccessExpression(parentNode)) {
+							const parentNodeName = parentNode.getName();
+
+							parentNode.replaceWithText(
+								`${vdName}?.${parentNodeName}`,
+							);
+						}
+					}
+				});
+
+				grandparent.remove();
+
+				requiresPathname.set((set) => set.add(vdName));
+			}
 		}
 	}
 };

--- a/codemods/ts-morph/next/13/replace-next-router/index.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/index.ts
@@ -122,7 +122,15 @@ const handleRouterPropertyAccessExpression = (
 	} else if (nodeName === 'isReady') {
 		node.replaceWithText('true');
 	} else if (nodeName === 'asPath') {
-		node.replaceWithText('pathname');
+		const parentNode = node.getParent();
+
+		if (Node.isPropertyAccessExpression(parentNode)) {
+			const rightNode = parentNode.getName();
+
+			parentNode.replaceWithText(`pathname?.${rightNode}`);
+		} else {
+			node.replaceWithText('pathname');
+		}
 
 		onReplacedWithPathname();
 	} else if (nodeName === 'href') {

--- a/codemods/ts-morph/next/13/replace-next-router/index.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/index.ts
@@ -8,6 +8,9 @@ import {
 import { PropertyAccessExpression, SourceFile, ts } from 'ts-morph';
 import { Node } from 'ts-morph';
 
+// how to fix router events (manually)
+// https://nextjs.org/docs/app/api-reference/functions/use-router#router-events
+
 export const buildContainer = <T>(initialValue: T) => {
 	let currentValue: T = initialValue;
 
@@ -289,6 +292,24 @@ const handleVariableDeclaration = (
 					});
 
 					++count;
+				} else if (text === 'asPath') {
+					++count;
+
+					nameNode.findReferencesAsNodes().forEach((node) => {
+						const parentNode = node.getParent();
+
+						if (Node.isPropertyAccessExpression(parentNode)) {
+							const rightNode = parentNode.getName();
+
+							parentNode.replaceWithText(
+								`pathname?.${rightNode}`,
+							);
+						} else {
+							node.replaceWithText('pathname');
+						}
+					});
+
+					requiresPathname.set((set) => set.add('pathname'));
 				}
 			}
 		}

--- a/codemods/ts-morph/next/13/replace-next-router/index.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/index.ts
@@ -110,6 +110,10 @@ const handleRouterPropertyAccessExpression = (
 
 		if (Node.isVariableDeclaration(parentNode)) {
 			parentNode.remove();
+		} else if (Node.isPropertyAccessExpression(parentNode)) {
+			const rightNode = parentNode.getName();
+
+			parentNode.replaceWithText(`pathname?.${rightNode}`);
 		} else {
 			node.replaceWithText('pathname');
 		}

--- a/codemods/ts-morph/next/13/replace-next-router/index.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/index.ts
@@ -112,9 +112,8 @@ const handleRouterPropertyAccessExpression = (
 	} else if (nodeName === 'isReady') {
 		node.replaceWithText('true');
 	} else if (nodeName === 'asPath') {
-		node.replaceWithText('`${pathname}?${searchParams}`');
+		node.replaceWithText('pathname');
 
-		onReplacedWithSearchParams();
 		onReplacedWithPathname();
 	} else if (nodeName === 'href') {
 		node.replaceWithText('pathname');

--- a/codemods/ts-morph/next/13/replace-next-router/test.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/test.ts
@@ -1025,4 +1025,50 @@ describe('next 13 replace-next-router', function () {
 
 		deepStrictEqual(actual, expected);
 	});
+
+	it('should replace router.asPath.startsWith with pathname?.startsWith', () => {
+		const beforeText = `
+			import { useRouter } from "next/router";
+		
+			export default function Component() {
+		  		const router = useRouter();
+		
+				useEffect(
+					() => {
+						router.replace("a");
+					},
+					[router]
+				);
+		
+				const a = router.asPath.startsWith("a");
+			
+				return null;
+			}
+		`;
+
+		const afterText = `
+			import { usePathname } from "next/navigation";
+			import { useRouter } from "next/navigation";
+			
+			export default function Component() {
+				const pathname = usePathname();
+				const router = useRouter();
+		
+				useEffect(
+					() => {
+						router.replace("a");
+					},
+					[router]
+				);
+		
+				const a = pathname?.startsWith("a");
+			
+				return null;
+			}
+		`;
+
+		const { actual, expected } = transform(beforeText, afterText, '.tsx');
+
+		deepStrictEqual(actual, expected);
+	});
 });

--- a/codemods/ts-morph/next/13/replace-next-router/test.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/test.ts
@@ -1102,7 +1102,7 @@ describe('next 13 replace-next-router', function () {
 		deepStrictEqual(actual, expected);
 	});
 
-	it.only('should replace "path = useRouter().asPath" with "path = usePathname()"', () => {
+	it('should replace "path = useRouter().asPath" with "path = usePathname()"', () => {
 		const beforeText = `
 			import { useRouter } from "next/router";
 			

--- a/codemods/ts-morph/next/13/replace-next-router/test.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/test.ts
@@ -934,7 +934,7 @@ describe('next 13 replace-next-router', function () {
 		deepStrictEqual(actual, expected);
 	});
 
-	it.only('should retain the useRouter import when router is in use', () => {
+	it('should retain the useRouter import when router is in use', () => {
 		const beforeText = `
 			import { useRouter } from 'next/router'
 		

--- a/codemods/ts-morph/next/13/replace-next-router/test.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/test.ts
@@ -934,7 +934,7 @@ describe('next 13 replace-next-router', function () {
 		deepStrictEqual(actual, expected);
 	});
 
-	it('should retain the useRouter import when router is in use', () => {
+	it.only('should retain the useRouter import when router is in use', () => {
 		const beforeText = `
 			import { useRouter } from 'next/router'
 		

--- a/codemods/ts-morph/next/13/replace-next-router/test.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/test.ts
@@ -1025,46 +1025,4 @@ describe('next 13 replace-next-router', function () {
 
 		deepStrictEqual(actual, expected);
 	});
-
-	it('should use JSON.stringify for objects passed to router.push', () => {
-		const beforeText = `
-			import { useRouter } from 'next/router'
-		
-			const Component = () => {
-		  		const router = useRouter();
-
-				useEffect(() => {
-					router.push({
-						a: 1,
-						b: 2,
-						c: 3,
-					});
-				}, [router])
-
-				return null;
-			}
-		`;
-
-		const afterText = `
-			import { useRouter } from "next/navigation";
-			
-			const Component = () => {
-				const router = useRouter();
-
-				useEffect(() => {
-					router.push(JSON.stringify({
-						a: 1,
-						b: 2,
-						c: 3,
-					}));
-				}, [router])
-
-				return null;
-			}
-		`;
-
-		const { actual, expected } = transform(beforeText, afterText, '.js');
-
-		deepStrictEqual(actual, expected);
-	});
 });

--- a/codemods/ts-morph/next/13/replace-next-router/test.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/test.ts
@@ -1071,4 +1071,67 @@ describe('next 13 replace-next-router', function () {
 
 		deepStrictEqual(actual, expected);
 	});
+
+	it('should replace "{ asPath } = useRouter()" with "pathname = usePathname()"', () => {
+		const beforeText = `
+			import { useRouter } from "next/router";
+			
+			export default function Component() {
+				const { asPath } = useRouter();
+		
+				const a = asPath.startsWith("a");
+			
+				return null;
+			}
+		`;
+
+		const afterText = `
+			import { usePathname } from "next/navigation";
+			
+			export default function Component() {
+				const pathname = usePathname();
+		
+				const a = pathname?.startsWith("a");
+			
+				return null;
+			}
+		`;
+
+		const { actual, expected } = transform(beforeText, afterText, '.tsx');
+
+		deepStrictEqual(actual, expected);
+	});
+
+	it.only('should replace "path = useRouter().asPath" with "path = usePathname()"', () => {
+		const beforeText = `
+			import { useRouter } from "next/router";
+			
+			export default function Component() {
+				const path = useRouter().asPath;
+		
+				const a = path.startsWith("a");
+			
+				return null;
+			}
+		`;
+
+		const afterText = `
+			import { usePathname } from "next/navigation";
+			
+			export default function Component() {
+				const path = usePathname();
+		
+				const a = path?.startsWith("a");
+			
+				return null;
+			}
+		`;
+
+		const { actual, expected } = transform(beforeText, afterText, '.tsx');
+
+		deepStrictEqual(actual, expected);
+	});
+
+	// BreadcrumbContainer
+	// AppCard
 });

--- a/codemods/ts-morph/next/13/replace-next-router/test.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/test.ts
@@ -49,7 +49,7 @@ describe('next 13 replace-next-router', function () {
 
         function Component() {
             const searchParams = useSearchParams();
-            const x = searchParams.get("a");
+            const x = searchParams?.get("a");
         }
         `;
 
@@ -72,7 +72,7 @@ describe('next 13 replace-next-router', function () {
 
 			function Component() {
                 const searchParams = useSearchParams();
-				const a = searchParams.get("a");
+				const a = searchParams?.get("a");
 			}
         `;
 
@@ -97,7 +97,7 @@ describe('next 13 replace-next-router', function () {
 
 			function Component() {
                 const searchParams = useSearchParams();
-                const a = searchParams.get('a');
+                const a = searchParams?.get('a');
 			}
         `;
 
@@ -122,7 +122,7 @@ describe('next 13 replace-next-router', function () {
 
 			function Component() {
 				const searchParams = useSearchParams();
-				const a = searchParams.get('a');
+				const a = searchParams?.get('a');
 			}
 			`;
 
@@ -131,7 +131,7 @@ describe('next 13 replace-next-router', function () {
 		deepStrictEqual(actual, expected);
 	});
 
-	it('should replace "...?.query" with "...searchParams.entries()."', async function (this: Context) {
+	it('should replace "...?.query" with "Object.fromEntries(...)"', async function (this: Context) {
 		const beforeText = `
 			import { useRouter } from 'next/router';
 
@@ -148,7 +148,7 @@ describe('next 13 replace-next-router', function () {
 			function Component() {
 				const searchParams = useSearchParams();
 
-				const shallowCopiedQuery = { ...Object.fromEntries(searchParams) };
+				const shallowCopiedQuery = { ...Object.fromEntries(searchParams ?? new URLSearchParams()) };
 			}
 			`;
 
@@ -174,7 +174,7 @@ describe('next 13 replace-next-router', function () {
 			function Component() {
 				const searchParams = useSearchParams();
 
-				const a = searchParams.get("a");
+				const a = searchParams?.get("a");
 			}
         `;
 
@@ -197,7 +197,7 @@ describe('next 13 replace-next-router', function () {
 
 			function Component() {
 				const searchParams = useSearchParams();
-                const a = searchParams.get("a");
+                const a = searchParams?.get("a");
 			}
 			`;
 
@@ -225,9 +225,9 @@ describe('next 13 replace-next-router', function () {
 			function Component() {
 				const searchParams = useSearchParams();
 
-				const x = searchParams.get("a");
+				const x = searchParams?.get("a");
 
-				const z = { ...Object.fromEntries(searchParams), b: 1 };
+				const z = { ...Object.fromEntries(searchParams ?? new URLSearchParams()), b: 1 };
 			}
 		`;
 
@@ -236,7 +236,7 @@ describe('next 13 replace-next-router', function () {
 		deepStrictEqual(actual, expected);
 	});
 
-	it('should replace router.query.a with searchParams.get("a")', async function (this: Context) {
+	it('should replace router.query.a with searchParams?.get("a")', async function (this: Context) {
 		const beforeText = `
 			import { useRouter } from 'next/router';
 
@@ -261,8 +261,8 @@ describe('next 13 replace-next-router', function () {
 				const searchParams = useSearchParams()
 
 				const nextA = useMemo(
-					() => (searchParams.get("a") ? null : searchParams.get("b")),
-					[searchParams.get("a"), searchParams.get("b"), c],
+					() => (searchParams?.get("a") ? null : searchParams?.get("b")),
+					[searchParams?.get("a"), searchParams?.get("b"), c],
 				) ?? a;
 			}
 		`;
@@ -290,9 +290,9 @@ describe('next 13 replace-next-router', function () {
 			function Component() {
                 const searchParams = useSearchParams();
 
-				const a = searchParams.get("a"),
-                    b = searchParams.get("b"),
-                    c = searchParams.get("c");
+				const a = searchParams?.get("a"),
+                    b = searchParams?.get("b"),
+                    c = searchParams?.get("c");
 			}
         `;
 
@@ -374,7 +374,7 @@ describe('next 13 replace-next-router', function () {
 		deepStrictEqual(actual, undefined);
 	});
 
-	it('should replace { a } = query with a = searchParams.get("a")', async function (this: Context) {
+	it('should replace { a } = query with a = searchParams?.get("a")', async function (this: Context) {
 		const beforeText = `
 			import { useRouter } from 'next/router';
 
@@ -389,9 +389,9 @@ describe('next 13 replace-next-router', function () {
 
 			function Component() {
 				const searchParams = useSearchParams();
-				const a = searchParams.get("a");
-				const b = searchParams.get("b");
-				const c = searchParams.get("c");
+				const a = searchParams?.get("a");
+				const b = searchParams?.get("b");
+				const c = searchParams?.get("c");
 			}
 		`;
 
@@ -605,7 +605,7 @@ describe('next 13 replace-next-router', function () {
 			export function Component() {
 				const searchParams = useSearchParams();
 
-				if (searchParams.get('a') && searchParams.get('b')) {
+				if (searchParams?.get('a') && searchParams?.get('b')) {
 
 				}
 			}
@@ -661,7 +661,7 @@ describe('next 13 replace-next-router', function () {
 
 			export function Component() {
 				const searchParams = useSearchParams();
-				const a = searchParams.get(A);
+				const a = searchParams?.get(A);
 			}
 		`;
 
@@ -684,7 +684,7 @@ describe('next 13 replace-next-router', function () {
 
 			export function Component() {
 				const searchParams = useSearchParams();
-				const b = searchParams.get("a");
+				const b = searchParams?.get("a");
 			}
 		`;
 
@@ -797,7 +797,7 @@ describe('next 13 replace-next-router', function () {
 
 				return (
 					<div>
-						{searchParams.get('a')}
+						{searchParams?.get('a')}
 					</div>
 				)
 			}
@@ -808,7 +808,7 @@ describe('next 13 replace-next-router', function () {
 		deepStrictEqual(actual, expected);
 	});
 
-	it('should replace useRouter().query with ...Object.fromEntries(searchParams)', () => {
+	it('should replace useRouter().query with ...Object.fromEntries(searchParams ?? new URLSearchParams())', () => {
 		const beforeText = `
 			import React from 'react'
 			import { useRouter } from 'next/router'
@@ -831,7 +831,7 @@ describe('next 13 replace-next-router', function () {
 
 				return (
 					<>
-						<div>{JSON.stringify(...Object.fromEntries(searchParams)}</div>
+						<div>{JSON.stringify(...Object.fromEntries(searchParams ?? new URLSearchParams())}</div>
 					</>
 				)
 			}
@@ -968,7 +968,7 @@ describe('next 13 replace-next-router', function () {
 					[router]
 				);
 
-	   			const a = pathname.includes('a');
+	   			const a = pathname?.includes('a');
 			return null;
 		};
  

--- a/codemods/ts-morph/next/13/replace-next-router/test.ts
+++ b/codemods/ts-morph/next/13/replace-next-router/test.ts
@@ -719,7 +719,7 @@ describe('next 13 replace-next-router', function () {
 		deepStrictEqual(actual, expected);
 	});
 
-	it('should replace router.asPath with pathname and searchParams', async function (this: Context) {
+	it('should replace router.asPath with pathname', async function (this: Context) {
 		const beforeText = `
 			import { useRouter } from 'next/router';
 
@@ -732,13 +732,11 @@ describe('next 13 replace-next-router', function () {
 
 		const afterText = `
 			import { usePathname } from "next/navigation";
-			import { useSearchParams } from "next/navigation";
 
 			export function Component() {
-				const searchParams = useSearchParams();
 				const pathname = usePathname();
 
-				return <b>{\`\${pathname}?\${searchParams}\`}</b>;
+				return <b>{pathname}</b>;
 			}
 		`;
 
@@ -862,14 +860,12 @@ describe('next 13 replace-next-router', function () {
 
 		const afterText = `
 			import { usePathname } from "next/navigation";
-			import { useSearchParams } from "next/navigation";
 			import { useEffect } from 'react';
 
 			function Component() {
-				const searchParams = useSearchParams();
 				const pathname = usePathname();
 
-				const [path,] = useState(true ? \`\${pathname}?\${searchParams}\` : pathname);
+				const [path,] = useState(true ? pathname : pathname);
 
 				return null;
 			}


### PR DESCRIPTION
https://linear.app/intuita/issue/INT-1003/produce-nullability-checks-in-the-nextrouter-codemod

Changes:
* modify access for objects returned from usePathname and useSearchParams so nullability is always taken into account
* handle the usages of asPath → this becomes now pathname