### PR TITLE
Fix/add decorator for get static props

### DIFF
--- a/next/13/remove-get-static-props/test.ts
+++ b/next/13/remove-get-static-props/test.ts
@@ -369,7 +369,6 @@ describe('next 13 remove-get-static-props', function () {
 		};
 
 		const actualOutput = transform(fileInfo, buildApi('tsx'), {});
-
 		assert.deepEqual(
 			actualOutput?.replace(/\W/gm, ''),
 			OUTPUT?.replace(/\W/gm, ''),
@@ -597,7 +596,7 @@ describe('next 13 remove-get-static-props', function () {
 	  };
 
 		export async function generateStaticParams() {
-			return (await _getStaticPaths({})).paths;
+			return (await getStaticPaths({})).paths;
 		}
 		
 		async function getData(ctx: GetStaticPropsContext){
@@ -605,7 +604,7 @@ describe('next 13 remove-get-static-props', function () {
 		}
 
 		export 
-	  async function _getStaticPaths() {
+	  async function getStaticPaths() {
 	    return {
 	            paths: [{ params: { id: '1' } }, { params: { id: '2' } }],
 							fallback: true,
@@ -676,7 +675,7 @@ describe('next 13 remove-get-static-props', function () {
 	  };
 
 		export async function generateStaticParams() {
-			return (await _getStaticPaths({})).paths;
+			return (await getStaticPaths({})).paths;
 		}
 		
 		async function getData(ctx: GetStaticPropsContext){
@@ -684,7 +683,7 @@ describe('next 13 remove-get-static-props', function () {
 		}
 
 		export 
-	  async function _getStaticPaths() {
+	  async function getStaticPaths() {
 	    return {
 	            paths: [{ params: { id: '1' } }, { params: { id: '2' } }],
 							fallback: false,
@@ -753,7 +752,7 @@ describe('next 13 remove-get-static-props', function () {
 	  };
 
 		export async function generateStaticParams() {
-			return (await _getStaticPaths({})).paths;
+			return (await getStaticPaths({})).paths;
 		}
 
 		async function getData(ctx: GetStaticPropsContext){
@@ -761,7 +760,7 @@ describe('next 13 remove-get-static-props', function () {
 		}
 
 		export
-	  async function _getStaticPaths() {
+	  async function getStaticPaths() {
 	    return {
 	            paths: [{ params: { id: '1' } }, { params: { id: '2' } }],
 							fallback: 'blocking',

--- a/next/13/remove-get-static-props/test.ts
+++ b/next/13/remove-get-static-props/test.ts
@@ -36,9 +36,7 @@ describe('next 13 remove-get-static-props', function () {
 		const OUTPUT = `
 			import { GetStaticPropsContext } from 'next';
 			async function getData(ctx: GetStaticPropsContext){
-				const users = await promise;
-
-				return { users };
+				return (await getStaticProps(ctx)).props;
 			}
 
 			export
@@ -48,7 +46,7 @@ describe('next 13 remove-get-static-props', function () {
 				return { props: { users } };
 			}
 
-			export default async function Component({params }) {
+			export default async function Component({ params }) {
 				const {users} = await getData({
 					params, 
 				});
@@ -84,10 +82,8 @@ describe('next 13 remove-get-static-props', function () {
 
 		const OUTPUT = `
 			import { GetStaticPropsContext } from 'next';
-			async function getData(context: GetStaticPropsContext){
-				const users = await promise(context.params);
-				const res = { props: { users } };
-				return res.props;
+			async function getData(ctx: GetStaticPropsContext){
+				return (await getStaticProps(ctx)).props;
 			}
 
 			export async function getStaticProps(context: GetStaticPropsContext) {
@@ -132,8 +128,7 @@ describe('next 13 remove-get-static-props', function () {
 		const OUTPUT = `
 			import { GetStaticPropsContext } from 'next';
 			async function getData(ctx: GetStaticPropsContext){
-				const allPosts = await promise;
-				return { allPosts } ;
+				return (await getStaticProps(ctx)).props;
 			}
 
 			export 
@@ -179,11 +174,8 @@ describe('next 13 remove-get-static-props', function () {
 		const OUTPUT = `
 		import { GetStaticPropsContext } from 'next';
 		async function getData(ctx: GetStaticPropsContext){
-				const users = await promise;
-				const groups = await anotherPromise;
-
-				return { users, groups }
-			}
+			return (await getStaticProps(ctx)).props;
+		}
 
 			export 
 			async function getStaticProps() {
@@ -234,11 +226,8 @@ describe('next 13 remove-get-static-props', function () {
 		const OUTPUT = `
 		import { GetStaticPropsContext } from 'next';
 		async function getData(ctx: GetStaticPropsContext){
-				const users = await promise;
-				const groups = await anotherPromise;
-
-				return { users, groups }
-			}
+			return (await getStaticProps(ctx)).props;
+		}
 
 			export
 			async function getStaticProps() {
@@ -293,11 +282,8 @@ describe('next 13 remove-get-static-props', function () {
 		const OUTPUT = `
 		import { GetStaticPropsContext } from 'next';
 			import x from "y";
-			async function getData(ctx: GetStaticPropsContext) {
-				const users = await promise;
-				const groups = await anotherPromise;
-
-				return { users, groups }
+			async function getData(ctx: GetStaticPropsContext){
+				return (await getStaticProps(ctx)).props;
 			}
 
 			export
@@ -354,11 +340,8 @@ describe('next 13 remove-get-static-props', function () {
 			import { GetStaticPropsContext } from 'next';
 			import x from "y";
 
-			async function getData(ctx: GetStaticPropsContext) {
-				const users = await promise;
-				const groups = await anotherPromise;
-
-				return { users, groups };
+			async function getData(ctx: GetStaticPropsContext){
+				return (await getStaticProps(ctx)).props;
 			}
 
 			export const getStaticProps = 
@@ -418,17 +401,9 @@ describe('next 13 remove-get-static-props', function () {
 		const OUTPUT = `
 		import { GetStaticPropsContext } from 'next';
 			import x from "y";
-			async function getData(ctx: GetStaticPropsContext) {
-				const users = await promise;
-				const groups = await anotherPromise;
-
-				if(false) {
-					return { users, groups };
-				}
-
-				return { users, groups };
+			async function getData(ctx: GetStaticPropsContext){
+				return (await getStaticProps(ctx)).props;
 			}
-
 
 			export const getStaticProps =  
 			 async () => {
@@ -491,15 +466,8 @@ describe('next 13 remove-get-static-props', function () {
 		import { GetStaticPropsContext } from 'next';
 			import x from "y";
 			
-			async function getData(ctx: GetStaticPropsContext) {
-				const users = await promise;
-				const groups = await anotherPromise;
-
-				if(false) {
-					return { users, groups };
-				}
-
-				return { users, groups };
+			async function getData(ctx: GetStaticPropsContext){
+				return (await getStaticProps(ctx)).props;
 			}
 
 			export const getStaticProps = 
@@ -559,13 +527,9 @@ describe('next 13 remove-get-static-props', function () {
 
 		const OUTPUT = `
 		import { GetServerSidePropsContext } from 'next';
-			async function getData(ctx: GetServerSidePropsContext) {
-				const res = await fetch(\`https://...\`);
-				const projects = await res.json();
-
-				return { projects };
+			async function getData(ctx: GetServerSidePropsContext){
+				return (await getServerSideProps(ctx)).props;
 			}
-
 			export
 			async function getServerSideProps() {
 				const res = await fetch(\`https://...\`);
@@ -636,11 +600,8 @@ describe('next 13 remove-get-static-props', function () {
 			return (await _getStaticPaths({})).paths;
 		}
 		
-		async function getData({ params }: GetStaticPropsContext) {
-			const res = await fetch(\`https://.../posts/\${params.id}\`);
-			const post = await res.json();
-
-			return { post };
+		async function getData(ctx: GetStaticPropsContext){
+			return (await getStaticProps(ctx)).props;
 		}
 
 		export 
@@ -718,11 +679,8 @@ describe('next 13 remove-get-static-props', function () {
 			return (await _getStaticPaths({})).paths;
 		}
 		
-		async function getData({params}:GetStaticPropsContext ) {
-			const res = await fetch(\`https://.../posts/\${params.id}\`);
-			const post = await res.json();
-
-			return { post }
+		async function getData(ctx: GetStaticPropsContext){
+			return (await getStaticProps(ctx)).props;
 		}
 
 		export 
@@ -798,11 +756,8 @@ describe('next 13 remove-get-static-props', function () {
 			return (await _getStaticPaths({})).paths;
 		}
 
-		async function getData({params}: GetStaticPropsContext) {
-			const res = await fetch(\`https://.../posts/\${params.id}\`);
-			const post = await res.json();
-
-			return { post };
+		async function getData(ctx: GetStaticPropsContext){
+			return (await getStaticProps(ctx)).props;
 		}
 
 		export

--- a/next/13/replace-next-head/index.ts
+++ b/next/13/replace-next-head/index.ts
@@ -998,13 +998,24 @@ export const handleSourceFile = (
 			buildMetadataStatement(metadataObject),
 		);
 	}
-	
-	const importAlreadyExists = sourceFile.getImportDeclarations().find(declaration => {
-			const specifier =declaration.getImportClause()?.getNamedImports().find(imp => imp.getNameNode().getText() === 'Metadata') ?? null;
-			return specifier !== null && declaration.getModuleSpecifier().getText() === '"next"';
+
+	const importAlreadyExists = sourceFile
+		.getImportDeclarations()
+		.find((declaration) => {
+			const specifier =
+				declaration
+					.getImportClause()
+					?.getNamedImports()
+					.find(
+						(imp) => imp.getNameNode().getText() === 'Metadata',
+					) ?? null;
+			return (
+				specifier !== null &&
+				declaration.getModuleSpecifier().getText() === '"next"'
+			);
 		});
-	
-	if(!importAlreadyExists) {
+
+	if (!importAlreadyExists) {
 		sourceFile.insertStatements(
 			0,
 			`import { Metadata  ${


### PR DESCRIPTION
- add `getStaticProps` decorator instead of searching for return statements and modifiying them;
- do not rename old data fetching methods (_getStaticProps), next.js will not complain on the method name in app dir, if it does not have `export` keyword, so we can keep the name.