### PR TITLE
wrap getStaticProps only if some return statement args are not object…

### DIFF
--- a/next/13/remove-get-static-props/index.ts
+++ b/next/13/remove-get-static-props/index.ts
@@ -1,5 +1,6 @@
 import {
 	API,
+	ASTNode,
 	ArrowFunctionExpression,
 	Collection,
 	File,
@@ -104,10 +105,13 @@ const generateStaticParamsMethodFactory = (j: JSCodeshift) => {
 	return j.exportNamedDeclaration(functionDeclaration.value);
 };
 
-const getDataMethodFactory = (j: JSCodeshift, decoratedMethodName: string) => {
+const getDataMethodFactory = (
+	j: JSCodeshift,
+	decoratedFunctionName: string,
+) => {
 	return j(`
 	async function getData({ params }: { params: Params }) {
-		const result = await ${decoratedMethodName}({ params });
+		const result = await ${decoratedFunctionName}({ params });
 		
 		if("redirect" in result) {
 			redirect(result.redirect.destination);	
@@ -221,7 +225,11 @@ const addImportStatement: ModFunction<File, 'write'> = (j, root, settings) => {
 	return [false, []];
 };
 
-const addGetDataFunction: ModFunction<File, 'write'> = (j, root, settings) => {
+const addGetDataFunctionAsWrapper: ModFunction<File, 'write'> = (
+	j,
+	root,
+	settings,
+) => {
 	const functionName = settings.functionName as string;
 
 	const getDataFunctionDeclaration = getDataMethodFactory(j, functionName);
@@ -260,6 +268,177 @@ const addGetDataFunction: ModFunction<File, 'write'> = (j, root, settings) => {
 	];
 };
 
+const deepCloneCollection = <T extends ASTNode>(
+	j: JSCodeshift,
+	root: Collection<T>,
+) => {
+	return j(root.toSource());
+};
+
+const addGetDataFunctionInline: ModFunction<File, 'write'> = (
+	j,
+	root,
+	settings,
+) => {
+	const clonedFunctionCollection = deepCloneCollection(
+		j,
+		settings.function as Collection<FunctionDeclaration>,
+	);
+
+	const clonedFunctionDeclarationCollection = clonedFunctionCollection.find(
+		j.FunctionDeclaration,
+	);
+	const clonedFArrowFunctionExpressionCollection =
+		clonedFunctionCollection.find(j.ArrowFunctionExpression);
+
+	const clonedFunction =
+		clonedFunctionDeclarationCollection.paths()[0] ??
+		clonedFArrowFunctionExpressionCollection.paths()[0] ??
+		null;
+
+	if (clonedFunction === null) {
+		return [false, []];
+	}
+
+	let usedRedirect = false;
+	let usedNotFound = false;
+
+	clonedFunctionCollection
+		.find(j.ReturnStatement)
+		.forEach((returnStatementPath) => {
+			const { argument } = returnStatementPath.value;
+
+			if (j.ObjectExpression.check(argument)) {
+				j(argument)
+					.find(j.ObjectProperty)
+					.forEach((property) => {
+						if (
+							!j.ObjectExpression.check(property.value.value) ||
+							!j.Identifier.check(property.value.key)
+						) {
+							return;
+						}
+
+						const { key, value } = property.value;
+
+						if (key.name === 'props') {
+							returnStatementPath.value.argument = value;
+						}
+
+						if (key.name === 'redirect') {
+							j(value)
+								.find(j.ObjectProperty, {
+									key: {
+										type: 'Identifier',
+										name: 'destination',
+									},
+								})
+								.forEach((objectPropertyPath) => {
+									if (
+										!j.StringLiteral.check(
+											objectPropertyPath.value.value,
+										) &&
+										!j.Identifier.check(
+											objectPropertyPath.value.value,
+										)
+									) {
+										return;
+									}
+
+									returnStatementPath.value.argument =
+										j.callExpression(
+											j.identifier('redirect'),
+											[objectPropertyPath.value.value],
+										);
+								});
+
+							usedRedirect = true;
+						}
+
+						if (key.name === 'notFound') {
+							returnStatementPath.value.argument =
+								j.callExpression(j.identifier('notFound'), []);
+
+							usedNotFound = true;
+						}
+					});
+			}
+		});
+
+	const objPattern = j.objectPattern([
+		j.property.from({
+			kind: 'init',
+			key: j.identifier('params'),
+			value: j.identifier('params'),
+			shorthand: true,
+		}),
+	]);
+	const objectTypeAnnotation = j.objectTypeAnnotation([
+		j.objectTypeProperty(
+			j.identifier('params'),
+			j.genericTypeAnnotation(j.identifier('Params'), null),
+			false,
+		),
+	]);
+	const typeAnnotation = j.typeAnnotation(objectTypeAnnotation);
+	objPattern.typeAnnotation = typeAnnotation;
+
+	const getDataFunctionDeclaration = j.functionDeclaration.from({
+		params: [objPattern],
+		body:
+			clonedFunction.value.body.type === 'BlockStatement'
+				? clonedFunction.value.body
+				: j.blockStatement([]),
+		id: j.identifier('getData'),
+		async: true,
+	});
+
+	const program = root.find(j.Program);
+
+	const programNode = program.paths()[0] ?? null;
+
+	if (programNode === null) {
+		return [false, []];
+	}
+
+	programNode.value.body.splice(
+		getFirstIndexAfterExportNamedFunctionDeclaration(
+			j,
+			root.find(j.Program).paths()[0]?.value.body ?? [],
+			settings.functionName as string,
+		),
+		0,
+		getDataFunctionDeclaration,
+	);
+
+	const lazyModFunctions: LazyModFunction[] = [];
+
+	const specifierNames: string[] = [];
+
+	if (usedNotFound) {
+		specifierNames.push('notFound');
+	}
+
+	if (usedRedirect) {
+		specifierNames.push('redirect');
+	}
+
+	if (specifierNames.length !== 0) {
+		lazyModFunctions.push([
+			addImportStatement,
+			root,
+			{
+				specifierNames: specifierNames.join(),
+				sourceName: 'next/navigation',
+			},
+		]);
+	}
+
+	lazyModFunctions.push([addPageParamsTypeAlias, root, {}]);
+
+	return [true, lazyModFunctions];
+};
+
 const DATA_FETCHING_METHOD_NAMES = ['getServerSideProps', 'getStaticProps'];
 
 export const findFunctionDeclarations: ModFunction<File, 'read'> = (
@@ -283,20 +462,19 @@ export const findFunctionDeclarations: ModFunction<File, 'read'> = (
 		if (DATA_FETCHING_METHOD_NAMES.includes(id.name)) {
 			lazyModFunctions.push(
 				[
-					addGetDataFunction,
-					root,
+					findReturnStatements,
+					functionDeclarationCollection,
 					{
 						...settings,
 						functionName: id.name,
 					},
 				],
-				[findReturnStatements, functionDeclarationCollection, settings],
 				[findComponentFunctionDefinition, root, settings],
 			);
 		}
 
 		if (id.name === 'getStaticPaths') {
-			const newSettings = { ...settings, methodName: 'getStaticPaths' };
+			const newSettings = { ...settings, functionName: 'getStaticPaths' };
 
 			lazyModFunctions.push(
 				[
@@ -334,17 +512,12 @@ export const findArrowFunctionExpressions: ModFunction<File, 'read'> = (
 			if (DATA_FETCHING_METHOD_NAMES.includes(id.name)) {
 				lazyModFunctions.push(
 					[
-						addGetDataFunction,
-						root,
+						findReturnStatements,
+						j(arrowFunctionExpressionPath),
 						{
 							...settings,
 							functionName: id.name,
 						},
-					],
-					[
-						findReturnStatements,
-						j(arrowFunctionExpressionPath),
-						settings,
 					],
 					[findComponentFunctionDefinition, root, settings],
 				);
@@ -353,7 +526,7 @@ export const findArrowFunctionExpressions: ModFunction<File, 'read'> = (
 			if (id.name === 'getStaticPaths') {
 				const newSettings = {
 					...settings,
-					methodName: 'getStaticPaths',
+					functionName: 'getStaticPaths',
 				};
 
 				lazyModFunctions.push(
@@ -381,10 +554,11 @@ export const findReturnStatements: ModFunction<FunctionDeclaration, 'read'> = (
 ) => {
 	const lazyModFunctions: LazyModFunction[] = [];
 
-	root.find(j.ReturnStatement).forEach((returnStatementPath) => {
-		const returnStatementCollection = j(returnStatementPath);
+	const returnStatementCollection = root.find(j.ReturnStatement);
 
-		if (settings.methodName === 'getStaticPaths') {
+	returnStatementCollection.forEach((returnStatementPath) => {
+		const returnStatementCollection = j(returnStatementPath);
+		if (settings.functionName === 'getStaticPaths') {
 			lazyModFunctions.push([
 				findFallbackObjectProperty,
 				returnStatementCollection,
@@ -401,6 +575,27 @@ export const findReturnStatements: ModFunction<FunctionDeclaration, 'read'> = (
 		]);
 	});
 
+	if (settings.functionName === 'getStaticPaths') {
+		return [false, lazyModFunctions];
+	}
+
+	const methodCanBeInlined = returnStatementCollection.every(
+		(returnStatementPath) =>
+			j.ObjectExpression.check(returnStatementPath.value.argument),
+	);
+
+	const file = root.closest(j.File);
+
+	if (methodCanBeInlined) {
+		lazyModFunctions.push([
+			addGetDataFunctionInline,
+			file,
+			{ ...settings, function: root },
+		]);
+	} else {
+		lazyModFunctions.push([addGetDataFunctionAsWrapper, file, settings]);
+	}
+
 	return [false, lazyModFunctions];
 };
 
@@ -416,7 +611,6 @@ export const findFallbackObjectProperty: ModFunction<any, 'read'> = (
 	const lazyModFunctions: LazyModFunction[] = [];
 
 	const fileCollection = root.closest(j.File);
-
 	root.find(j.ObjectProperty, {
 		key: {
 			type: 'Identifier',

--- a/next/13/remove-get-static-props/test.ts
+++ b/next/13/remove-get-static-props/test.ts
@@ -34,35 +34,29 @@ describe('next 13 remove-get-static-props', function () {
 	      `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
-			type Params = {
-				[key: string]: string | string[] | undefined
-			};
+		type Params = {
+			[key: string]: string | string[] | undefined
+		};
 
-			type PageProps = {
-					params: Params
-			};
-
+		type PageProps = {
+				params: Params
+		};
+		
 			export async function getStaticProps() {
 				const users = await promise;
 
 				return { props: { users } };
 			}
 
-			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
-			}
+			async function getData(
+				{
+						params
+				}: { params: Params }
+		) {
+				const users = await promise;
+
+				return { users };
+		}
 
 			export default async function Component({ params }: PageProps) {
 				const {users} = await getData({
@@ -79,7 +73,6 @@ describe('next 13 remove-get-static-props', function () {
 		};
 
 		const actualOutput = transform(fileInfo, buildApi('tsx'));
-
 		assert.deepEqual(
 			actualOutput?.replace(/\W/gm, ''),
 			OUTPUT.replace(/\W/gm, ''),
@@ -164,8 +157,6 @@ describe('next 13 remove-get-static-props', function () {
 	      `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -173,24 +164,15 @@ describe('next 13 remove-get-static-props', function () {
 			type PageProps = {
 					params: Params
 			};
-
+			
 			export async function getStaticProps() {
 				const allPosts = await promise;
 				return { props: { allPosts } };
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				const allPosts = await promise;
+				return  { allPosts };
 			}
 
 			export default async function Component({ params }: PageProps) {
@@ -206,7 +188,6 @@ describe('next 13 remove-get-static-props', function () {
 		};
 
 		const actualOutput = transform(fileInfo, buildApi('tsx'));
-
 		assert.deepEqual(
 			actualOutput?.replace(/\W/gm, ''),
 			OUTPUT.replace(/\W/gm, ''),
@@ -228,8 +209,6 @@ describe('next 13 remove-get-static-props', function () {
 	      `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -244,19 +223,12 @@ describe('next 13 remove-get-static-props', function () {
 
 				return { props: { users, groups }, revalidate: 1 };
 			}
-
+			
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-					redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-					notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				const users = await promise;
+				const groups = await anotherPromise;
+
+				return { users, groups };
 			}
 
 			export default async function Component({ params }: PageProps) {
@@ -296,8 +268,6 @@ describe('next 13 remove-get-static-props', function () {
 	    `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -310,19 +280,10 @@ describe('next 13 remove-get-static-props', function () {
 				const users = await promise;
 				return { props: { users } };
 			}
-
+			
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				const users = await promise;
+				return { users };
 			}
 
 			async function SingleAppPage({ params }: PageProps) {
@@ -361,8 +322,6 @@ describe('next 13 remove-get-static-props', function () {
 	    `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -376,19 +335,9 @@ describe('next 13 remove-get-static-props', function () {
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				return { a } ;
 			}
-
+			
 			export async function SingleAppPage({ params }: PageProps) {
 				const props = await getData({ params });
 				return null;
@@ -423,8 +372,6 @@ describe('next 13 remove-get-static-props', function () {
 	    `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -438,19 +385,9 @@ describe('next 13 remove-get-static-props', function () {
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				return { a } ;
 			}
-
+			
 			export const SingleAppPage = async ({ params }: PageProps) => {
 				const props = await getData({ params });
 				return null;
@@ -475,7 +412,7 @@ describe('next 13 remove-get-static-props', function () {
 		const INPUT = `
 			export async function getStaticProps() {
 				sideEffect();
-				return { props: { } };
+				return { props: { a } };
 			}
 
 			export const SingleAppPage = () => {
@@ -487,8 +424,6 @@ describe('next 13 remove-get-static-props', function () {
 	    `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -499,21 +434,12 @@ describe('next 13 remove-get-static-props', function () {
 
 			export async function getStaticProps() {
 				sideEffect();
-				return { props: { } };
+				return { props: { a } };
 			}
-
+			
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				sideEffect();
+				return { a } ;
 			}
 
 			export const SingleAppPage = async ({ params }: PageProps) => {
@@ -549,8 +475,6 @@ describe('next 13 remove-get-static-props', function () {
 	    `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -563,19 +487,10 @@ describe('next 13 remove-get-static-props', function () {
 				const users = await promise;
 				return { props: { users } };
 			}
-
+			
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				const users = await promise;
+				return { users } ;
 			}
 
 			const Home = async ({ params }: PageProps) => {
@@ -611,7 +526,6 @@ describe('next 13 remove-get-static-props', function () {
 	    `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			
 			type Params = {
 				[key: string]: string | string[] | undefined
@@ -625,21 +539,12 @@ describe('next 13 remove-get-static-props', function () {
 				const users = await promise;
 				return { props: { users } };
 			}
-
+			
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-					redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-					notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				const users = await promise;
+				return { users } ;
 			}
-
+			
 			const Home = async ({ params }: PageProps) => {
 				const { users } = await getData({ params });
 				return (<><Component users={users} /></>)
@@ -675,8 +580,6 @@ describe('next 13 remove-get-static-props', function () {
 	    `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -689,19 +592,10 @@ describe('next 13 remove-get-static-props', function () {
 				const users = await promise;
 				return { props: { users } };
 			}
-
+			
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				const users = await promise;
+				return { users } ;
 			}
 
 			const AppPage: AppPageType['default'] = async function AppPage({ params }: PageProps) {
@@ -741,9 +635,7 @@ describe('next 13 remove-get-static-props', function () {
 			}
 	      `;
 
-		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
-			
+		const OUTPUT = `	
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -760,17 +652,9 @@ describe('next 13 remove-get-static-props', function () {
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				const users = await promise;
+				const groups = await anotherPromise;
+				return { users, groups } ;
 			}
 
 			export default async function Component({params}: PageProps) {
@@ -816,7 +700,6 @@ describe('next 13 remove-get-static-props', function () {
 	      `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			import x from "y";
 			
 			type Params = {
@@ -833,21 +716,13 @@ describe('next 13 remove-get-static-props', function () {
 
 				return { props: { users, groups }, revalidate: 1 };
 			}
-
+			
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-					redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-					notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				const users = await promise;
+				const groups = await anotherPromise;
+				return { users, groups } ;
 			}
-
+			
 			export default async function Component({ params }: PageProps) {
 				const { users, groups } = await getData(params);
 
@@ -891,7 +766,6 @@ describe('next 13 remove-get-static-props', function () {
 	      `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			import x from "y";
 			
 			type Params = {
@@ -910,19 +784,11 @@ describe('next 13 remove-get-static-props', function () {
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
-				
-				if("redirect" in result) {
-					redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-					notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				const users = await promise;
+				const groups = await anotherPromise;
+				return { users, groups } ;
 			}
-
+			
 			export default async function Component({ params }: PageProps) {
 				const { users, groups } = await getData({ params });
 
@@ -970,7 +836,6 @@ describe('next 13 remove-get-static-props', function () {
 	      `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			import x from "y";
 			
 			type Params = {
@@ -991,19 +856,16 @@ describe('next 13 remove-get-static-props', function () {
 
 				return { props: { users, groups }, revalidate: 1 };
 			}
-
+			
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
+				const users = await promise;
+				const groups = await anotherPromise;
 				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
+				if(false) {
+					return  { users, groups }
 				}
 				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				return { users, groups } ;
 			}
 
 			export default async function Component({ params }: PageProps) {
@@ -1053,7 +915,6 @@ describe('next 13 remove-get-static-props', function () {
 	      `;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			import x from "y";
 			
 			type Params = {
@@ -1074,19 +935,16 @@ describe('next 13 remove-get-static-props', function () {
 
 				return { props: { users, groups }, revalidate: 1 };
 			}
-
+			
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
+				const users = await promise;
+				const groups = await anotherPromise;
 				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
+				if(false) {
+					return  { users, groups }
 				}
 				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				return { users, groups } ;
 			}
 
 			export default async function Component({ params }: PageProps) {
@@ -1134,7 +992,6 @@ describe('next 13 remove-get-static-props', function () {
 		`;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			type Params = {
 				[key: string]: string | string[] | undefined
 			};
@@ -1151,17 +1008,10 @@ describe('next 13 remove-get-static-props', function () {
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getServerSideProps({ params });
+				const res = await fetch(\`https://...\`);
+				const projects = await res.json();
 				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				return { projects } ;
 			}
 
 			export default async function Dashboard({ params }: PageProps) {
@@ -1213,7 +1063,6 @@ describe('next 13 remove-get-static-props', function () {
 		`;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			import PostLayout from '@/components/post-layout';
 		
 			type Params = {
@@ -1243,17 +1092,10 @@ describe('next 13 remove-get-static-props', function () {
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
+				const res = await fetch(\`https://.../posts/\${params.id}\`);
+				const post = await res.json();
 				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				return { post } ;
 			}
 
 			export default async function Post({ params }: PageProps) {
@@ -1301,7 +1143,6 @@ describe('next 13 remove-get-static-props', function () {
 		`;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			import PostLayout from '@/components/post-layout';
 		
 			type Params = {
@@ -1331,17 +1172,10 @@ describe('next 13 remove-get-static-props', function () {
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
+				const res = await fetch(\`https://.../posts/\${params.id}\`);
+				const post = await res.json();
 				
-				if("redirect" in result) {
-						redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-						notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				return { post } ;
 			}
 
 			export default async function Post({ params }: PageProps) {
@@ -1389,7 +1223,6 @@ describe('next 13 remove-get-static-props', function () {
 		`;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			import PostLayout from '@/components/post-layout';
 		
 			type Params = {
@@ -1419,17 +1252,10 @@ describe('next 13 remove-get-static-props', function () {
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
+				const res = await fetch(\`https://.../posts/\${params.id}\`);
+				const post = await res.json();
 				
-				if("redirect" in result) {
-					redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-					notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				return { post } ;
 			}
 
 			export default async function Post({ params }: PageProps) {
@@ -1477,7 +1303,6 @@ describe('next 13 remove-get-static-props', function () {
 		`;
 
 		const OUTPUT = `
-			import { notFound, redirect } from "next/navigation";
 			import PostLayout from '@/components/post-layout';
 		
 			type Params = {
@@ -1507,17 +1332,10 @@ describe('next 13 remove-get-static-props', function () {
 			}
 
 			async function getData({ params }: { params: Params }) {
-				const result = await getStaticProps({ params });
+				const res = await fetch(\`https://.../posts/\${params.id}\`);
+				const post = await res.json();
 				
-				if("redirect" in result) {
-					redirect(result.redirect.destination);
-				}
-				
-				if("notFound" in result) {
-					notFound();
-				}
-				
-				return "props" in result ? result.props : {};
+				return { post } ;
 			}
 
 			export default async function Post({ params }: PageProps) {
@@ -1536,6 +1354,66 @@ describe('next 13 remove-get-static-props', function () {
 
 		const actualOutput = transform(fileInfo, buildApi('tsx'));
 
+		assert.deepEqual(
+			actualOutput?.replace(/\W/gm, ''),
+			OUTPUT.replace(/\W/gm, ''),
+		);
+	});
+
+	it('should wrap original getStaticProps when at least one of returnStatement argument is not ObjectExpression', function () {
+		const INPUT = `
+			export async function getStaticProps() {
+				return fetchData();
+			}
+
+			export default function Component({ users }) {
+				return users.map(user => <b>user</b>)
+	          }
+	      `;
+
+		const OUTPUT = `
+		import { notFound, redirect } from "next/navigation";
+		type Params = {
+			[key: string]: string | string[] | undefined
+		};
+
+		type PageProps = {
+				params: Params
+		};
+		
+			export async function getStaticProps() {
+				return fetchData();
+			}
+
+			async function getData({ params }: { params: Params }) {
+				const result = await getStaticProps({ params });
+				
+				if("redirect" in result) {
+						redirect(result.redirect.destination);
+				}
+				
+				if("notFound" in result) {
+						notFound();
+				}
+				
+				return "props" in result ? result.props : {};
+		}
+
+			export default async function Component({ params }: PageProps) {
+				const {users} = await getData({
+					params, 
+				});
+
+				return users.map(user => <b>user</b>)
+			}
+		`;
+
+		const fileInfo: FileInfo = {
+			path: 'index.js',
+			source: INPUT,
+		};
+
+		const actualOutput = transform(fileInfo, buildApi('tsx'));
 		assert.deepEqual(
 			actualOutput?.replace(/\W/gm, ''),
 			OUTPUT.replace(/\W/gm, ''),


### PR DESCRIPTION
https://linear.app/intuita/issue/INT-1528/wrap-the-hook-only-if-it-returns-at-least-1-expression