### PR TITLE
INT-1550 create page and components files for routes (WiP)

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,5 +1,5 @@
 loader:
     - 'ts-node/esm'
 full-trace: true
-bail: true
+# bail: true
 spec: './**/test.ts'

--- a/next/13/app-directory-boilerplate/index.ts
+++ b/next/13/app-directory-boilerplate/index.ts
@@ -68,24 +68,16 @@ export default function NotFound() {
 }
 `;
 
-const ROUTE_NOT_FOUND_COMPONENT = `
-'use client';
-import ErrorPage from 'next/error';
-
-const NotFound = () => <ErrorPage statusCode={404} />;
-
-export default NotFound;
-`;
-
 enum FilePurpose {
 	// root directory
 	ROOT_LAYOUT = 'ROOT_LAYOUT',
 	ROOT_ERROR = 'ROOT_ERROR',
 	ROOT_PAGE = 'ROOT_PAGE',
+	ROOT_COMPONENTS = 'ROOT_COMPONENTS',
 	ROOT_NOT_FOUND = 'ROOT_NOT_FOUND',
 	// route directories
 	ROUTE_PAGE = 'ROUTE_PAGE',
-	ROUTE_NOT_FOUND_COMPONENT = 'ROUTE_NOT_FOUND_COMPONENT',
+	ROUTE_COMPONENTS = 'ROUTE_COMPONENTS',
 }
 
 const map = new Map([
@@ -93,19 +85,25 @@ const map = new Map([
 	[FilePurpose.ROOT_ERROR, ROOT_ERROR_CONTENT],
 	[FilePurpose.ROOT_NOT_FOUND, ROOT_NOT_FOUND_CONTENT],
 	[FilePurpose.ROOT_PAGE, ''],
+	[FilePurpose.ROOT_COMPONENTS, ''],
 	[FilePurpose.ROUTE_PAGE, ''],
-	[FilePurpose.ROUTE_NOT_FOUND_COMPONENT, ROUTE_NOT_FOUND_COMPONENT],
+	[FilePurpose.ROUTE_COMPONENTS, ''],
 ]);
 
 const EXTENSION = '.tsx';
 
 type FileAPI = Parameters<NonNullable<Repomod<Dependencies>['handleFile']>>[0];
+type DataAPI = Parameters<NonNullable<Repomod<Dependencies>['handleData']>>[0];
 
 type Unpromisify<T> = T extends Promise<infer U> ? U : never;
 
 type FileCommand = Unpromisify<
 	ReturnType<NonNullable<Repomod<Dependencies>['handleFile']>>
 >[number];
+
+type DataCommand = Unpromisify<
+	ReturnType<NonNullable<Repomod<Dependencies>['handleData']>>
+>;
 
 const getCssImportDeclarationsFromUnderscoreApp = async (
 	parsedPath: ParsedPath,
@@ -250,6 +248,371 @@ export const removeNextDocumentImport = (sourceFile: SourceFile) => {
 	importDeclaration?.remove();
 };
 
+const removeUnneededImportDeclarations = (sourceFile: SourceFile) => {
+	sourceFile
+		.getImportDeclarations()
+		.filter((declaration) => {
+			if (
+				declaration.getModuleSpecifier().getLiteralText() ===
+					'next/head' &&
+				declaration.getImportClause()?.getText() === 'Head'
+			) {
+				return true;
+			}
+
+			const defaultImport = declaration.getDefaultImport() ?? null;
+
+			if (defaultImport !== null) {
+				const text = defaultImport.getText();
+
+				return (
+					sourceFile
+						.getDescendantsOfKind(tsmorph.ts.SyntaxKind.Identifier)
+						.filter((identifier) => identifier.getText() === text)
+						.length === 1
+				);
+			}
+
+			return declaration.getNamedImports().every((namedImport) => {
+				const text = namedImport.getText();
+
+				return (
+					sourceFile
+						.getDescendantsOfKind(tsmorph.ts.SyntaxKind.Identifier)
+						.filter((identifier) => identifier.getText() === text)
+						.length === 1
+				);
+			});
+		})
+		.forEach((declaration) => {
+			declaration.remove();
+		});
+};
+
+const buildComponentsFileData = (
+	api: DataAPI,
+	path: string,
+	options: Readonly<Record<string, string | undefined>>,
+	filePurpose: FilePurpose.ROOT_COMPONENTS | FilePurpose.ROUTE_COMPONENTS,
+): DataCommand => {
+	const { tsmorph, parseMdx, stringifyMdx, visitMdxAst } =
+		api.getDependencies();
+
+	let sourcingStatementInserted = false;
+
+	const rewriteWithTsMorph = (input: string) => {
+		const project = new tsmorph.Project({
+			useInMemoryFileSystem: true,
+			skipFileDependencyResolution: true,
+			compilerOptions: {
+				allowJs: true,
+			},
+		});
+
+		const sourceFile = project.createSourceFile(
+			options.oldPath ?? '',
+			input,
+		);
+
+		sourceFile.getFunctions().forEach((fn) => {
+			const id = fn.getName() ?? '';
+
+			if (
+				[
+					'getStaticProps',
+					'getServerSideProps',
+					'getStaticPaths',
+					'generateMetadata',
+				].includes(id)
+			) {
+				fn.remove();
+			}
+		});
+
+		sourceFile.getVariableStatements().forEach((statement) => {
+			statement.getDeclarations().forEach((declaration) => {
+				const id = declaration.getName() ?? '';
+
+				if (
+					[
+						'getStaticProps',
+						'getServerSideProps',
+						'getStaticPaths',
+						'generateMetadata',
+						'metadata',
+					].includes(id)
+				) {
+					declaration.remove();
+				}
+			});
+		});
+
+		removeUnneededImportDeclarations(sourceFile);
+
+		sourceFile
+			.getDescendantsOfKind(SyntaxKind.JsxOpeningElement)
+			.filter(
+				(jsxOpeningElement) =>
+					jsxOpeningElement.getTagNameNode().getText() === 'Head',
+			)
+			.map((declaration) => {
+				return declaration.getFirstAncestorByKind(
+					SyntaxKind.JsxElement,
+				);
+			})
+			.forEach((jsxElement) => {
+				const parenthesizedExpressionParent =
+					jsxElement?.getParentIfKind(
+						SyntaxKind.ParenthesizedExpression,
+					) ?? null;
+
+				if (parenthesizedExpressionParent !== null) {
+					parenthesizedExpressionParent.replaceWithText('null');
+
+					return;
+				}
+
+				jsxElement?.replaceWithText('');
+			});
+
+		if (filePurpose === FilePurpose.ROUTE_COMPONENTS) {
+			sourceFile.getImportDeclarations().forEach((declaration) => {
+				const moduleSpecifier = declaration.getModuleSpecifierValue();
+
+				if (moduleSpecifier.startsWith('./')) {
+					declaration.setModuleSpecifier(`.${moduleSpecifier}`);
+				} else if (moduleSpecifier.startsWith('../')) {
+					declaration.setModuleSpecifier(`../${moduleSpecifier}`);
+				}
+			});
+		}
+
+		if (!sourcingStatementInserted) {
+			sourceFile.insertStatements(0, [
+				`'use client';`,
+				`// This file has been sourced from: ${options.oldPath}`,
+			]);
+
+			sourcingStatementInserted = true;
+		}
+
+		return sourceFile.print();
+	};
+
+	if (path.endsWith('.mdx')) {
+		if (parseMdx && stringifyMdx && visitMdxAst) {
+			const tree = parseMdx(options.oldData ?? '');
+
+			visitMdxAst(tree, (node) => {
+				if (node.type === 'mdxjsEsm') {
+					node.value = rewriteWithTsMorph(node.value);
+
+					delete node.data;
+					delete node.position;
+
+					return 'skip';
+				}
+			});
+
+			const data = stringifyMdx(tree);
+
+			return {
+				kind: 'upsertData',
+				path,
+				data,
+			};
+		} else {
+			return {
+				kind: 'noop',
+			};
+		}
+	}
+
+	return {
+		kind: 'upsertData',
+		path,
+		data: rewriteWithTsMorph(options.oldData ?? ''),
+	};
+};
+
+const buildPageFileData = (
+	api: DataAPI,
+	path: string,
+	options: Readonly<Record<string, string | undefined>>,
+	filePurpose: FilePurpose.ROOT_PAGE | FilePurpose.ROUTE_PAGE,
+): DataCommand => {
+	const { tsmorph, parseMdx, stringifyMdx, visitMdxAst } =
+		api.getDependencies();
+
+	let sourcingStatementInserted = false;
+
+	const rewriteWithTsMorph = (input: string): string => {
+		const project = new tsmorph.Project({
+			useInMemoryFileSystem: true,
+			skipFileDependencyResolution: true,
+			compilerOptions: {
+				allowJs: true,
+			},
+		});
+
+		const sourceFile = project.createSourceFile(
+			options.oldPath ?? '',
+			input,
+		);
+
+		sourceFile.getFunctions().forEach((fn) => {
+			if (fn.isDefaultExport()) {
+				fn.remove();
+				return;
+			}
+
+			const id = fn.getName() ?? '';
+
+			if (
+				[
+					'getStaticProps',
+					'getServerSideProps',
+					'getStaticPaths',
+				].includes(id)
+			) {
+				fn.setIsExported(false);
+			}
+		});
+
+		sourceFile.getVariableStatements().forEach((statement) => {
+			statement.getDeclarations().forEach((declaration) => {
+				const id = declaration.getName() ?? '';
+
+				if (
+					[
+						'getStaticProps',
+						'getServerSideProps',
+						'getStaticPaths',
+					].includes(id) &&
+					declaration.hasExportKeyword()
+				) {
+					statement.setIsExported(false);
+				}
+			});
+		});
+
+		removeUnneededImportDeclarations(sourceFile);
+
+		sourceFile
+			.getDescendantsOfKind(SyntaxKind.JsxOpeningElement)
+			.filter(
+				(jsxOpeningElement) =>
+					jsxOpeningElement.getTagNameNode().getText() === 'Head',
+			)
+			.map((declaration) => {
+				return declaration.getFirstAncestorByKind(
+					SyntaxKind.JsxElement,
+				);
+			})
+			.forEach((jsxElement) => {
+				const parenthesizedExpressionParent =
+					jsxElement?.getParentIfKind(
+						SyntaxKind.ParenthesizedExpression,
+					) ?? null;
+
+				if (parenthesizedExpressionParent !== null) {
+					parenthesizedExpressionParent.replaceWithText('null');
+
+					return;
+				}
+
+				jsxElement?.replaceWithText('');
+			});
+
+		if (filePurpose === FilePurpose.ROUTE_PAGE) {
+			sourceFile.getImportDeclarations().forEach((declaration) => {
+				const moduleSpecifier = declaration.getModuleSpecifierValue();
+
+				if (moduleSpecifier.startsWith('./')) {
+					declaration.setModuleSpecifier(`.${moduleSpecifier}`);
+				} else if (moduleSpecifier.startsWith('../')) {
+					declaration.setModuleSpecifier(`../${moduleSpecifier}`);
+				}
+			});
+		}
+
+		sourceFile.addImportDeclaration({
+			moduleSpecifier: './components',
+			defaultImport: 'Components',
+		});
+
+		sourceFile.getStatementsWithComments().forEach((statement, index) => {
+			if (tsmorph.Node.isVariableStatement(statement)) {
+				const declarations = statement
+					.getDeclarationList()
+					.getDeclarations();
+
+				const getServerSidePropsUsed = declarations.some(
+					(declaration) =>
+						declaration.getName() === 'getServerSideProps',
+				);
+
+				if (getServerSidePropsUsed) {
+					sourceFile.insertStatements(
+						index,
+						'// TODO reimplement getServerSideProps with custom logic\n',
+					);
+				}
+			}
+		});
+
+		if (!sourcingStatementInserted) {
+			sourceFile.insertStatements(
+				0,
+				`// This file has been sourced from: ${options.oldPath}`,
+			);
+
+			sourcingStatementInserted = true;
+		}
+
+		sourceFile.addStatements(`export default async function Page(props: any) {
+			return <Components {...props} />;
+		}`);
+
+		return sourceFile.print();
+	};
+
+	if (path.endsWith('.mdx')) {
+		if (parseMdx && stringifyMdx && visitMdxAst) {
+			const tree = parseMdx(options.oldData ?? '');
+
+			visitMdxAst(tree, (node) => {
+				if (node.type === 'mdxjsEsm') {
+					node.value = rewriteWithTsMorph(node.value);
+
+					delete node.data;
+					delete node.position;
+
+					return 'skip';
+				}
+			});
+
+			const data = stringifyMdx(tree);
+
+			return {
+				kind: 'upsertData',
+				path,
+				data,
+			};
+		} else {
+			return {
+				kind: 'noop',
+			};
+		}
+	}
+
+	return {
+		kind: 'upsertData',
+		path,
+		data: rewriteWithTsMorph(options.oldData ?? ''),
+	};
+};
+
 export const repomod: Repomod<Dependencies> = {
 	includePatterns: ['**/pages/**/*.{js,jsx,ts,tsx,cjs,mjs,mdx}'],
 	excludePatterns: ['**/node_modules/**', '**/pages/api/**'],
@@ -270,13 +633,6 @@ export const repomod: Repomod<Dependencies> = {
 				.concat('app')
 				.join(posix.sep);
 
-			const rootLayoutPath = posix.format({
-				root: parsedPath.root,
-				dir: newDir,
-				ext: EXTENSION,
-				name: 'layout',
-			});
-
 			const rootErrorPath = posix.format({
 				root: parsedPath.root,
 				dir: newDir,
@@ -289,13 +645,6 @@ export const repomod: Repomod<Dependencies> = {
 				dir: newDir,
 				ext: EXTENSION,
 				name: 'not-found',
-			});
-
-			const rootPagePath = posix.format({
-				root: parsedPath.root,
-				dir: newDir,
-				ext: EXTENSION,
-				name: 'page',
 			});
 
 			const jsxErrorPath = posix.format({
@@ -345,7 +694,12 @@ export const repomod: Repomod<Dependencies> = {
 			const commands: FileCommand[] = [
 				{
 					kind: 'upsertFile' as const,
-					path: rootLayoutPath,
+					path: posix.format({
+						root: parsedPath.root,
+						dir: newDir,
+						ext: EXTENSION,
+						name: 'layout',
+					}),
 					options: {
 						...options,
 						filePurpose: FilePurpose.ROOT_LAYOUT,
@@ -354,10 +708,30 @@ export const repomod: Repomod<Dependencies> = {
 				},
 				{
 					kind: 'upsertFile' as const,
-					path: rootPagePath,
+					path: posix.format({
+						root: parsedPath.root,
+						dir: newDir,
+						ext: EXTENSION,
+						name: 'page',
+					}),
 					options: {
 						...options,
 						filePurpose: FilePurpose.ROOT_PAGE,
+						oldPath: path,
+						oldData,
+					},
+				},
+				{
+					kind: 'upsertFile' as const,
+					path: posix.format({
+						root: parsedPath.root,
+						dir: newDir,
+						ext: EXTENSION,
+						name: 'components',
+					}),
+					options: {
+						...options,
+						filePurpose: FilePurpose.ROOT_COMPONENTS,
 						oldPath: path,
 						oldData,
 					},
@@ -390,24 +764,6 @@ export const repomod: Repomod<Dependencies> = {
 				});
 			}
 
-			if (oldData.includes('next/error')) {
-				const notFoundPath = posix.format({
-					root: parsedPath.root,
-					dir: newDir,
-					ext: '.tsx',
-					name: 'notFound',
-				});
-
-				commands.push({
-					kind: 'upsertFile' as const,
-					path: notFoundPath,
-					options: {
-						...options,
-						filePurpose: FilePurpose.ROUTE_NOT_FOUND_COMPONENT,
-					},
-				});
-			}
-
 			return commands;
 		}
 
@@ -422,22 +778,35 @@ export const repomod: Repomod<Dependencies> = {
 
 			const newDir = newDirArr.join(posix.sep);
 
-			const routePagePath = posix.format({
-				root: parsedPath.root,
-				dir: newDir,
-				ext: parsedPath.ext === '.mdx' ? '.mdx' : '.tsx',
-				name: 'page',
-			});
-
 			const oldData = await api.readFile(path);
 
-			const commands: FileCommand[] = [
+			return [
 				{
 					kind: 'upsertFile',
-					path: routePagePath,
+					path: posix.format({
+						root: parsedPath.root,
+						dir: newDir,
+						ext: parsedPath.ext === '.mdx' ? '.mdx' : '.tsx',
+						name: 'page',
+					}),
 					options: {
 						...options,
 						filePurpose: FilePurpose.ROUTE_PAGE,
+						oldPath: path,
+						oldData,
+					},
+				},
+				{
+					kind: 'upsertFile',
+					path: posix.format({
+						root: parsedPath.root,
+						dir: newDir,
+						ext: parsedPath.ext === '.mdx' ? '.mdx' : '.tsx',
+						name: 'components',
+					}),
+					options: {
+						...options,
+						filePurpose: FilePurpose.ROUTE_COMPONENTS,
 						oldPath: path,
 						oldData,
 					},
@@ -447,26 +816,6 @@ export const repomod: Repomod<Dependencies> = {
 					path,
 				},
 			];
-
-			if (oldData.includes('next/error')) {
-				const notFoundPath = posix.format({
-					root: parsedPath.root,
-					dir: newDir,
-					ext: '.tsx',
-					name: 'notFound',
-				});
-
-				commands.push({
-					kind: 'upsertFile',
-					path: notFoundPath,
-					options: {
-						...options,
-						filePurpose: FilePurpose.ROUTE_NOT_FOUND_COMPONENT,
-					},
-				});
-			}
-
-			return commands;
 		}
 
 		if (parsedPath.name === '_app' || parsedPath.name === '_document') {
@@ -498,270 +847,19 @@ export const repomod: Repomod<Dependencies> = {
 		}
 
 		if (
-			(filePurpose === FilePurpose.ROUTE_PAGE ||
-				filePurpose === FilePurpose.ROOT_PAGE) &&
+			(filePurpose === FilePurpose.ROOT_COMPONENTS ||
+				filePurpose === FilePurpose.ROUTE_COMPONENTS) &&
 			options.oldPath
 		) {
-			const { tsmorph, parseMdx, stringifyMdx, visitMdxAst } =
-				api.getDependencies();
+			return buildComponentsFileData(api, path, options, filePurpose);
+		}
 
-			let sourcingStatementInserted = false;
-
-			const rewriteWithTsMorph = (input: string) => {
-				const project = new tsmorph.Project({
-					useInMemoryFileSystem: true,
-					skipFileDependencyResolution: true,
-					compilerOptions: {
-						allowJs: true,
-					},
-				});
-
-				const newSourceFile = project.createSourceFile(path, content);
-
-				const oldSourceFile = project.createSourceFile(
-					options.oldPath ?? '',
-					input,
-				);
-
-				oldSourceFile.getFunctions().forEach((fn) => {
-					const id = fn.getName() ?? '';
-					if (
-						[
-							'getStaticProps',
-							'getServerSideProps',
-							'getStaticPaths',
-						].includes(id)
-					) {
-						fn.setIsExported(false);
-					}
-				});
-
-				oldSourceFile.getVariableStatements().forEach((statement) => {
-					const declarations = statement.getDeclarations();
-
-					declarations.forEach((declaration) => {
-						const id = declaration.getName() ?? '';
-
-						if (
-							[
-								'getStaticProps',
-								'getServerSideProps',
-								'getStaticPaths',
-							].includes(id)
-						) {
-							if (declaration.hasExportKeyword()) {
-								statement.setIsExported(false);
-							}
-						}
-					});
-				});
-
-				oldSourceFile
-					.getImportDeclarations()
-					.filter((declaration) => {
-						return (
-							declaration
-								.getModuleSpecifier()
-								.getLiteralText() === 'next/head' &&
-							declaration.getImportClause()?.getText() === 'Head'
-						);
-					})
-					.forEach((declaration) => {
-						declaration.remove();
-					});
-
-				oldSourceFile
-					.getDescendantsOfKind(SyntaxKind.JsxOpeningElement)
-					.filter(
-						(jsxOpeningElement) =>
-							jsxOpeningElement.getTagNameNode().getText() ===
-							'Head',
-					)
-					.map((declaration) => {
-						return declaration.getFirstAncestorByKind(
-							SyntaxKind.JsxElement,
-						);
-					})
-					.forEach((jsxElement) => {
-						const parenthesizedExpressionParent =
-							jsxElement?.getParentIfKind(
-								SyntaxKind.ParenthesizedExpression,
-							) ?? null;
-
-						if (parenthesizedExpressionParent !== null) {
-							parenthesizedExpressionParent.replaceWithText(
-								'null',
-							);
-
-							return;
-						}
-
-						jsxElement?.replaceWithText('');
-					});
-
-				let nextErrorComponentName = '';
-
-				oldSourceFile
-					.getImportDeclarations()
-					.filter((declaration) => {
-						return (
-							declaration
-								.getModuleSpecifier()
-								.getLiteralText() === 'next/error'
-						);
-					})
-					.forEach((declaration) => {
-						nextErrorComponentName =
-							declaration.getImportClause()?.getText() ?? '';
-
-						declaration.remove();
-					});
-
-				if (nextErrorComponentName !== '') {
-					oldSourceFile
-						.getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
-						.filter((element) => {
-							return (
-								element.getTagNameNode().getText() ===
-									nextErrorComponentName &&
-								element
-									.getAttributes()
-									.some(({ compilerNode }) => {
-										return (
-											compilerNode.kind ===
-												SyntaxKind.JsxAttribute &&
-											compilerNode.name.getText() ===
-												'statusCode' &&
-											compilerNode.initializer?.kind ===
-												SyntaxKind.JsxExpression &&
-											compilerNode.initializer.expression?.getText() ===
-												'404'
-										);
-									})
-							);
-						})
-						.forEach((element) => {
-							element.replaceWithText('<NotFound />');
-
-							oldSourceFile.addImportDeclaration({
-								moduleSpecifier: './notFound',
-								defaultImport: 'NotFound',
-							});
-						});
-				}
-
-				oldSourceFile
-					.getStatementsWithComments()
-					.forEach((statement) => {
-						if (tsmorph.Node.isImportDeclaration(statement)) {
-							const structure = statement.getStructure();
-
-							if (filePurpose === FilePurpose.ROUTE_PAGE) {
-								if (
-									structure.moduleSpecifier !==
-										'./notFound' &&
-									structure.moduleSpecifier.startsWith('./')
-								) {
-									structure.moduleSpecifier = `.${structure.moduleSpecifier}`;
-								} else if (
-									structure.moduleSpecifier.startsWith('../')
-								) {
-									structure.moduleSpecifier = `../${structure.moduleSpecifier}`;
-								}
-							}
-
-							newSourceFile.addImportDeclaration(structure);
-
-							return;
-						}
-
-						if (tsmorph.Node.isVariableStatement(statement)) {
-							const declarations = statement
-								.getDeclarationList()
-								.getDeclarations();
-
-							const getStaticPathUsed = declarations.some(
-								(declaration) => {
-									return (
-										declaration.getName() ===
-										'getStaticPath'
-									);
-								},
-							);
-
-							if (getStaticPathUsed) {
-								newSourceFile.addStatements(
-									`// TODO reimplement getStaticPath as generateStaticParams\n`,
-								);
-							}
-
-							const getServerSidePropsUsed = declarations.some(
-								(declaration) => {
-									return (
-										declaration.getName() ===
-										'getServerSideProps'
-									);
-								},
-							);
-
-							if (getServerSidePropsUsed) {
-								newSourceFile.addStatements(
-									`// TODO reimplement getServerSideProps with custom logic\n`,
-								);
-							}
-						}
-
-						newSourceFile.addStatements(statement.print());
-					});
-
-				if (!sourcingStatementInserted) {
-					newSourceFile.insertStatements(
-						0,
-						`// This file has been sourced from: ${options.oldPath}`,
-					);
-
-					sourcingStatementInserted = true;
-				}
-
-				return newSourceFile.print();
-			};
-
-			if (path.endsWith('.mdx')) {
-				if (parseMdx && stringifyMdx && visitMdxAst) {
-					const tree = parseMdx(options.oldData ?? '');
-
-					visitMdxAst(tree, (node) => {
-						if (node.type === 'mdxjsEsm') {
-							node.value = rewriteWithTsMorph(node.value);
-
-							delete node.data;
-							delete node.position;
-
-							return 'skip';
-						}
-					});
-
-					const data = stringifyMdx(tree);
-
-					return {
-						kind: 'upsertData',
-						path,
-						data,
-					};
-				} else {
-					return {
-						kind: 'noop',
-					};
-				}
-			}
-
-			const data = rewriteWithTsMorph(options.oldData ?? '');
-
-			return {
-				kind: 'upsertData',
-				path,
-				data,
-			};
+		if (
+			(filePurpose === FilePurpose.ROOT_PAGE ||
+				filePurpose === FilePurpose.ROUTE_PAGE) &&
+			options.oldPath
+		) {
+			return buildPageFileData(api, path, options, filePurpose);
 		}
 
 		if (filePurpose === FilePurpose.ROOT_LAYOUT) {

--- a/next/13/app-directory-boilerplate/test.ts
+++ b/next/13/app-directory-boilerplate/test.ts
@@ -34,7 +34,7 @@ const A_B_CONTENT = `
 import { X } from "../../testABC";
 import { Y } from "./testDEF";
 
-export const getStaticPath = () => {
+export const getStaticPaths = () => {
 
 }
 `;
@@ -84,36 +84,6 @@ const transform = async (json: DirectoryJSON) => {
 	return executeRepomod(api, repomod, '/', {});
 };
 
-const A_B_DATA = `// This file has been sourced from: /opt/project/pages/[a]/[b].tsx
-import { X } from "../../../testABC";
-import { Y } from "../testDEF";
-// TODO reimplement getStaticPath as generateStaticParams
-export const getStaticPath = () => {
-};
-`;
-
-const A_B_MDX_DATA = `// This file has been sourced from: /opt/project/pages/[a]/[b].mdx
-import { X } from "../../../testABC";
-import { Y } from "../testDEF";
-
-
-// TODO reimplement getStaticPath as generateStaticParams
-export const getStaticPath = () => {
-};
-`;
-
-const A_C_DATA = `// This file has been sourced from: /opt/project/pages/[a]/c.tsx
-// TODO reimplement getServerSideProps with custom logic
-const getServerSideProps = () => {
-};
-`;
-
-const A_C_MDX_DATA = `// This file has been sourced from: /opt/project/pages/[a]/c.mdx
-// TODO reimplement getServerSideProps with custom logic
-const getServerSideProps = () => {
-};
-`;
-
 describe('next 13 app-directory-boilerplate', function () {
 	it('should build correct files', async function (this: Context) {
 		const externalFileCommands = await transform({
@@ -127,7 +97,7 @@ describe('next 13 app-directory-boilerplate', function () {
 			'/opt/project/pages/a/index.tsx': '',
 		});
 
-		deepStrictEqual(externalFileCommands.length, 13);
+		deepStrictEqual(externalFileCommands.length, 17);
 
 		ok(
 			externalFileCommands.some(
@@ -192,21 +162,16 @@ describe('next 13 app-directory-boilerplate', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/page.tsx' &&
+					command.path === '/opt/project/app/components.tsx' &&
 					command.data.replace(/\W/gm, '') ===
-						`// This file has been sourced from: /opt/project/pages/index.jsx
-						import A from "./testQWE";
+						`
+						'use client';
+						// This file has been sourced from: /opt/project/pages/index.jsx
 						
 						export default function Index({}) {
 							return null;
 						}
-						
-						const getStaticProps = async ({}) => {
-							return {
-								props: {},
-								revalidate: 10,
-							};
-						};`.replace(/\W/gm, '')
+					;`.replace(/\W/gm, '')
 				);
 			}),
 		);
@@ -217,7 +182,16 @@ describe('next 13 app-directory-boilerplate', function () {
 					command.kind === 'upsertFile' &&
 					command.path === '/opt/project/app/[a]/c/page.tsx' &&
 					command.data.replace(/\W/gm, '') ===
-						A_C_DATA.replace(/\W/gm, '')
+						`
+						// This file has been sourced from: /opt/project/pages/[a]/c.tsx
+						import Components from "./components";
+						// TODO reimplement getServerSideProps with custom logic
+						const getServerSideProps = () => {
+						};
+						export default async function Page(props: any) {
+							return <Components {...props}/>;
+						}
+					`.replace(/\W/gm, '')
 				);
 			}),
 		);
@@ -226,9 +200,21 @@ describe('next 13 app-directory-boilerplate', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/[a]/[b]/page.tsx' &&
+					command.path === '/opt/project/app/[a]/c/components.tsx' &&
 					command.data.replace(/\W/gm, '') ===
-						A_B_DATA.replace(/\W/gm, '')
+						"'use client';".replace(/\W/gm, '')
+				);
+			}),
+		);
+
+		ok(
+			externalFileCommands.some((command) => {
+				return (
+					command.kind === 'upsertFile' &&
+					command.path ===
+						'/opt/project/app/[a]/[b]/components.tsx' &&
+					command.data.replace(/\W/gm, '') ===
+						"'use client';".replace(/\W/gm, '')
 				);
 			}),
 		);
@@ -241,7 +227,7 @@ describe('next 13 app-directory-boilerplate', function () {
 			'/opt/project/pages/_document.jsx': '',
 		});
 
-		deepStrictEqual(externalFileCommands.length, 5);
+		deepStrictEqual(externalFileCommands.length, 6);
 
 		ok(
 			!externalFileCommands.some(
@@ -277,14 +263,15 @@ describe('next 13 app-directory-boilerplate', function () {
 			'/opt/project/pages/[a]/c.mdx': A_C_CONTENT,
 		});
 
-		deepStrictEqual(externalFileCommands.length, 9);
+		deepStrictEqual(externalFileCommands.length, 12);
 
 		ok(
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/[a]/c/page.mdx' &&
-					command.data === A_C_MDX_DATA
+					command.path === '/opt/project/app/[a]/c/components.mdx' &&
+					command.data.replace(/\W/gm, '') ===
+						`'use client';`.replace(/\W/gm, '')
 				);
 			}),
 		);
@@ -293,8 +280,10 @@ describe('next 13 app-directory-boilerplate', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/[a]/[b]/page.mdx' &&
-					command.data === A_B_MDX_DATA
+					command.path ===
+						'/opt/project/app/[a]/[b]/components.mdx' &&
+					command.data.replace(/\W/gm, '') ===
+						"'use client".replace(/\W/gm, '')
 				);
 			}),
 		);
@@ -302,34 +291,56 @@ describe('next 13 app-directory-boilerplate', function () {
 
 	it('should remove the Head tag', async function (this: Context) {
 		const content = `
-		import Head from 'next/head';
+			import Head from 'next/head';
 
-		export default async function Index() {
-			return <div>
-				<Head></Head>
-			</div>;
-		}
+			export default async function Index() {
+				return <div>
+					<Head></Head>
+				</div>;
+			}
 		`;
 
-		const newContent = `
-		// This file has been sourced from: /opt/project/pages/index.jsx
-
-		export default async function Index() {
-			return <div>
-			</div>;
-		}
-		`;
-
-		const [, upsertFileCommand, deleteIndexJsxCommand] = await transform({
+		const [
+			,
+			upsertPageCommand,
+			upsertComponentCommand,
+			deleteIndexJsxCommand,
+		] = await transform({
 			'/opt/project/pages/index.jsx': content,
 		});
 
-		deepStrictEqual(upsertFileCommand?.kind, 'upsertFile');
-		deepStrictEqual(upsertFileCommand?.path, '/opt/project/app/page.tsx');
+		//
+		deepStrictEqual(upsertPageCommand?.kind, 'upsertFile');
+		deepStrictEqual(upsertPageCommand?.path, '/opt/project/app/page.tsx');
 
 		deepStrictEqual(
-			upsertFileCommand?.data.replace(/\W/gm, ''),
-			newContent.replace(/\W/gm, ''),
+			upsertPageCommand?.data.replace(/\W/gm, ''),
+			`
+				// This file has been sourced from: /opt/project/pages/index.jsx
+				import Components from "./components";
+				export default async function Page(props: any) {
+					return <Components {...props}/>;
+				}
+			`.replace(/\W/gm, ''),
+		);
+
+		deepStrictEqual(upsertComponentCommand?.kind, 'upsertFile');
+		deepStrictEqual(
+			upsertComponentCommand?.path,
+			'/opt/project/app/components.tsx',
+		);
+
+		deepStrictEqual(
+			upsertComponentCommand?.data.replace(/\W/gm, ''),
+			`
+				'use client';
+				// This file has been sourced from: /opt/project/pages/index.jsx
+
+				export default async function Index() {
+					return <div>
+					</div>;
+				}
+			`.replace(/\W/gm, ''),
 		);
 
 		deepStrictEqual(deleteIndexJsxCommand?.kind, 'deleteFile');
@@ -341,33 +352,53 @@ describe('next 13 app-directory-boilerplate', function () {
 
 	it('should remove the Head tag when surrounded with ()', async function (this: Context) {
 		const content = `
-		import Head from "next/head";
+			import Head from "next/head";
 
-		export default function Index() {
-			return (
-				<Head></Head>
-			);
-		}
+			export default function Index() {
+				return (
+					<Head></Head>
+				);
+			}
 		`;
 
-		const newContent = `
-		// This file has been sourced from: /opt/project/pages/index.jsx
-
-		export default function Index() {
-			return null;
-		}
-		`;
-
-		const [, upsertFileCommand, deleteIndexJsxCommand] = await transform({
+		const [
+			,
+			upsertPageCommand,
+			upsertComponentCommand,
+			deleteIndexJsxCommand,
+		] = await transform({
 			'/opt/project/pages/index.jsx': content,
 		});
 
-		deepStrictEqual(upsertFileCommand?.kind, 'upsertFile');
-		deepStrictEqual(upsertFileCommand?.path, '/opt/project/app/page.tsx');
+		deepStrictEqual(upsertPageCommand?.kind, 'upsertFile');
+		deepStrictEqual(upsertPageCommand?.path, '/opt/project/app/page.tsx');
+		deepStrictEqual(
+			upsertPageCommand?.data.replace(/\W/gm, ''),
+			`
+				// This file has been sourced from: /opt/project/pages/index.jsx
+				import Components from "./components";
+				export default async function Page(props: any) {
+					return <Components {...props}/>;
+				}
+			`.replace(/\W/gm, ''),
+		);
+
+		deepStrictEqual(upsertComponentCommand?.kind, 'upsertFile');
+		deepStrictEqual(
+			upsertComponentCommand?.path,
+			'/opt/project/app/components.tsx',
+		);
 
 		deepStrictEqual(
-			upsertFileCommand?.data.replace(/\W/gm, ''),
-			newContent.replace(/\W/gm, ''),
+			upsertComponentCommand?.data.replace(/\W/gm, ''),
+			`
+				'use client';
+				// This file has been sourced from: /opt/project/pages/index.jsx
+
+				export default function Index() {
+					return null;
+				}
+			`.replace(/\W/gm, ''),
 		);
 
 		deepStrictEqual(deleteIndexJsxCommand?.kind, 'deleteFile');
@@ -441,8 +472,8 @@ describe('next 13 app-directory-boilerplate', function () {
 		const [
 			upsertLayoutCommand,
 			upsertPageCommand,
+			upsertComponentCommand,
 			deleteFileCommand,
-			upsertNotFoundFileCommand,
 		] = await transform({
 			'/opt/project/pages/index.tsx': index,
 		});
@@ -456,18 +487,35 @@ describe('next 13 app-directory-boilerplate', function () {
 		deepStrictEqual(upsertPageCommand?.kind, 'upsertFile');
 		deepStrictEqual(upsertPageCommand?.path, '/opt/project/app/page.tsx');
 
-		const pageData = `
-			This file has been sourced from: /opt/project/pages/index.tsx
-			import NotFound from "./notFound";
-
-			export default async function Index() {
-			    return <NotFound />;
-			}
-		`;
-
 		deepStrictEqual(
 			upsertPageCommand?.data.replace(/\W/gm, ''),
-			pageData.replace(/\W/gm, ''),
+			`
+				// This file has been sourced from: /opt/project/pages/index.tsx
+				
+				import Components from "./components";
+				export default async function Page(props: any) {
+					return <Components {...props}/>;
+				}
+			`.replace(/\W/gm, ''),
+		);
+
+		deepStrictEqual(upsertComponentCommand?.kind, 'upsertFile');
+		deepStrictEqual(
+			upsertComponentCommand?.path,
+			'/opt/project/app/components.tsx',
+		);
+
+		deepStrictEqual(
+			upsertComponentCommand?.data.replace(/\W/gm, ''),
+			`
+				'use client';
+				// This file has been sourced from: /opt/project/pages/index.tsx
+				import ErrorPage from "next/error";
+
+				export default async function Index() {
+					return <ErrorPage statusCode={404}/>;
+				}
+			`.replace(/\W/gm, ''),
 		);
 
 		// delete file command
@@ -475,27 +523,6 @@ describe('next 13 app-directory-boilerplate', function () {
 		deepStrictEqual(
 			deleteFileCommand?.path,
 			'/opt/project/pages/index.tsx',
-		);
-
-		// upsert not found file command
-		deepStrictEqual(upsertNotFoundFileCommand?.kind, 'upsertFile');
-		deepStrictEqual(
-			upsertNotFoundFileCommand?.path,
-			'/opt/project/app/notFound.tsx',
-		);
-
-		const data = `
-			'use client';
-			import ErrorPage from 'next/error';
-			
-			const NotFound = () => <ErrorPage statusCode={404} />;
-			
-			export default NotFound;
-		`;
-
-		deepStrictEqual(
-			upsertNotFoundFileCommand?.data.replace(/\W/gm, ''),
-			data.replace(/\W/gm, ''),
 		);
 	});
 
@@ -508,13 +535,10 @@ describe('next 13 app-directory-boilerplate', function () {
 			}
 		`;
 
-		const [
-			upsertPageCommand,
-			deleteFileCommand,
-			upsertNotFoundFileCommand,
-		] = await transform({
-			'/opt/project/pages/a/b/c.tsx': index,
-		});
+		const [upsertPageCommand, upsertComponentsCommand, deleteFileCommand] =
+			await transform({
+				'/opt/project/pages/a/b/c.tsx': index,
+			});
 
 		deepStrictEqual(upsertPageCommand?.kind, 'upsertFile');
 		deepStrictEqual(
@@ -522,18 +546,34 @@ describe('next 13 app-directory-boilerplate', function () {
 			'/opt/project/app/a/b/c/page.tsx',
 		);
 
-		const pageData = `
-			// This file has been sourced from: /opt/project/pages/a/b/c.tsx
-			import NotFound from "./notFound";
-
-			export default async function C() {
-			    return <NotFound />;
-			}
-		`;
-
 		deepStrictEqual(
 			upsertPageCommand?.data.replace(/(?!\.)\s/gm, ''),
-			pageData.replace(/(?!\.)\s/gm, ''),
+			`
+				// This file has been sourced from: /opt/project/pages/a/b/c.tsx
+				import Components from "./components";
+				export default async function Page(props: any) {
+					return <Components {...props}/>;
+				}
+			`.replace(/(?!\.)\s/gm, ''),
+		);
+
+		deepStrictEqual(upsertComponentsCommand?.kind, 'upsertFile');
+		deepStrictEqual(
+			upsertComponentsCommand?.path,
+			'/opt/project/app/a/b/c/components.tsx',
+		);
+
+		deepStrictEqual(
+			upsertComponentsCommand?.data.replace(/(?!\.)\s/gm, ''),
+			`
+				'use client';
+				// This file has been sourced from: /opt/project/pages/a/b/c.tsx
+				import ErrorPage from 'next/error';
+
+				export default async function C() {
+					return <ErrorPage statusCode={404}/>;
+				}
+			`.replace(/(?!\.)\s/gm, ''),
 		);
 
 		// delete file command
@@ -543,72 +583,121 @@ describe('next 13 app-directory-boilerplate', function () {
 			deleteFileCommand?.path,
 			'/opt/project/pages/a/b/c.tsx',
 		);
-
-		// upsert not found file command
-		deepStrictEqual(upsertNotFoundFileCommand?.kind, 'upsertFile');
-		deepStrictEqual(
-			upsertNotFoundFileCommand?.path,
-			'/opt/project/app/a/b/c/notFound.tsx',
-		);
-
-		const data = `
-			'use client';
-			import ErrorPage from 'next/error';
-
-			const NotFound = () => <ErrorPage statusCode={404} />;
-
-			export default NotFound;
-		`;
-
-		deepStrictEqual(
-			upsertNotFoundFileCommand?.data.replace(/\W/gm, ''),
-			data.replace(/\W/gm, ''),
-		);
 	});
 
-	it('should remove export keyword from old data fetching methods', async function (this: Context) {
+	it('should remove export keyword from old data fetching functions', async function (this: Context) {
 		const index = `
-			export async function getStaticProps() {};
-			export const getStaticProps = async () => {};
-			
-			export async function getServerSideProps() {};
-			export const getServerSideProps = async () => {};
-			
-			export async function getStaticPaths() {};
-			export const getStaticPaths = async () => {};
-				
-			export default async function Index() {
-					return null;
+			export async function getStaticProps() {}
+			export async function getServerSideProps() {}
+			export async function getStaticPaths() {}
+
+			export default function Index() {
+				return null;
 			}
 		`;
 
-		const [, command] = await transform({
+		const [, pageCommand, componentsCommand] = await transform({
 			'/opt/project/pages/index.tsx': index,
 		});
 
-		deepStrictEqual(command?.kind, 'upsertFile');
+		{
+			deepStrictEqual(pageCommand?.kind, 'upsertFile');
+			deepStrictEqual(pageCommand?.path, '/opt/project/app/page.tsx');
 
-		const pageData = `
-		// This file has been sourced from: /opt/project/pages/index.tsx
-		async function getStaticProps() { }
-		;
-		const getStaticProps = async () => { };
-		async function getServerSideProps() { };
-		
-		// TODO reimplement getServerSideProps with custom logic
-		const getServerSideProps = async () => { };
-		async function getStaticPaths() { };
-		
-		const getStaticPaths = async () => { };
-		
-		export default async function Index() {
-				return null;
+			deepStrictEqual(
+				pageCommand?.data.replace(/\W/gm, ''),
+				`
+					// This file has been sourced from: /opt/project/pages/index.tsx
+					import Components from "./components";
+					async function getStaticProps() { }
+					async function getServerSideProps() { }
+					async function getStaticPaths() { }
+					
+					export default async function Page(props: any) {
+						return <Components {...props}/>;
+					}
+				`.replace(/\W/gm, ''),
+			);
 		}
+
+		{
+			deepStrictEqual(componentsCommand?.kind, 'upsertFile');
+			deepStrictEqual(
+				componentsCommand?.path,
+				'/opt/project/app/components.tsx',
+			);
+
+			deepStrictEqual(
+				componentsCommand?.data.replace(/(?!\.)\s/gm, ''),
+				`
+					'use client';
+					// This file has been sourced from: /opt/project/pages/index.tsx
+					
+					export default function Index() {
+						return null;
+					}
+				`.replace(/(?!\.)\s/gm, ''),
+			);
+		}
+	});
+
+	it('should remove export keyword from old data fetching arrow functions', async function (this: Context) {
+		const index = `
+			export const getStaticProps = async () => {};
+			export const getServerSideProps = async () => {};
+			export const getStaticPaths = async () => {};
+
+			export default function Index() {
+				return null;
+			}
 		`;
 
-		deepStrictEqual(
-			command?.data.replace(/(?!\.)\s/gm, ''),
-			pageData.replace(/(?!\.)\s/gm, ''),
-		);
+		const [, pageCommand, componentsCommand] = await transform({
+			'/opt/project/pages/index.tsx': index,
+		});
+
+		{
+			deepStrictEqual(pageCommand?.kind, 'upsertFile');
+			deepStrictEqual(pageCommand?.path, '/opt/project/app/page.tsx');
+
+			deepStrictEqual(
+				pageCommand?.data.replace(/\W/gm, ''),
+				`
+					// This file has been sourced from: /opt/project/pages/index.tsx
+					import Components from "./components";
+					
+					const getStaticProps = async () => { };
+					
+					// TODO reimplement getServerSideProps with custom logic
+					const getServerSideProps = async () => { };
+					
+					const getStaticPaths = async () => { };
+					
+					export default async function Page(props: any) {
+						return <Components {...props}/>;
+					}
+				`.replace(/\W/gm, ''),
+			);
+		}
+
+		{
+			deepStrictEqual(componentsCommand?.kind, 'upsertFile');
+			deepStrictEqual(
+				componentsCommand?.path,
+				'/opt/project/app/components.tsx',
+			);
+
+			deepStrictEqual(
+				componentsCommand?.data.replace(/(?!\.)\s/gm, ''),
+				`
+					'use client';
+					// This file has been sourced from: /opt/project/pages/index.tsx
+					
+					export default function Index() {
+						return null;
+					}
+				`.replace(/(?!\.)\s/gm, ''),
+			);
+		}
 	});
 });

--- a/next/13/remove-get-static-props/test.ts
+++ b/next/13/remove-get-static-props/test.ts
@@ -1050,7 +1050,7 @@ describe('next 13 remove-get-static-props', function () {
 		};
 
 		const actualOutput = transform(fileInfo, buildApi('tsx'));
-		console.log(actualOutput, '?');
+
 		assert.deepEqual(
 			actualOutput?.replace(/\W/gm, ''),
 			OUTPUT?.replace(/\W/gm, ''),


### PR DESCRIPTION
Changes:
* do not generate not-found components
* create page and components files for routes 
* add 'use client' to the beginning of component files
* move the server-side methods to the page (server) files