### PR TITLE
INT-1755 Descriptions/links for ember.js array-wrapper and more

### DIFF
--- a/ember/5/array-wrapper/README.md
+++ b/ember/5/array-wrapper/README.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+This codemod removes any usage of `new` with `A`, and calls `A` as a standard function.
+
 ## Example
 
 ### Before:
@@ -46,4 +48,4 @@ jscodeshift
 
 ### Links for more info
 
--   https://github.com/ember-codemods/ember-3x-codemods/blob/master/transforms/array-wrapper
+-   https://deprecations.emberjs.com/v3.x/#toc_array-new-array-wrapper

--- a/ember/5/deprecate-merge/README.md
+++ b/ember/5/deprecate-merge/README.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+This codemod replaces all calls to `Ember.merge` with `Ember.assign`.
+
 ## Example
 
 ### Before:
@@ -52,4 +54,4 @@ jscodeshift
 
 ### Links for more info
 
--   https://github.com/ember-codemods/ember-3x-codemods/blob/master/transforms/deprecate-merge
+-   https://deprecations.emberjs.com/v3.x/#toc_ember-polyfills-deprecate-merge

--- a/ember/5/deprecate-router-events/README.md
+++ b/ember/5/deprecate-router-events/README.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+This codemod removes all calls to `willTransition` or `didTransition` events on the Router via usage of `routeWillChange` event listener and `routeDidChange` event listener.
+
 ## Example
 
 ### Before:
@@ -86,4 +88,4 @@ jscodeshift
 
 ### Links for more info
 
--   https://github.com/ember-codemods/ember-3x-codemods/blob/master/transforms/deprecate-router-events
+-   https://deprecations.emberjs.com/v3.x/#toc_deprecate-router-events

--- a/ember/5/object-new-constructor/README.md
+++ b/ember/5/object-new-constructor/README.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+`new EmberObject()` is deprecated in Ember.js v3.9 in favor of constructing instances of `EmberObject` and its subclasses. This codemod replaces all calls to `new EmberObject()` with `EmberObject.create()` and adds a `constructor` function to classes that extend from `EmberObject` so that the classes no longer extend from `EmberObject`.
+
 ## Example
 
 ### Before:
@@ -52,4 +54,4 @@ jscodeshift
 
 ### Links for more info
 
--   https://github.com/ember-codemods/ember-3x-codemods/blob/master/transforms/object-new-constructor
+-   https://deprecations.emberjs.com/v3.x/#toc_object-new-constructor


### PR DESCRIPTION
1. array-wrapper
-   https://deprecations.emberjs.com/v3.x/#toc_array-new-array-wrapper

2. deprecate-merge
-   https://deprecations.emberjs.com/v3.x/#toc_ember-polyfills-deprecate-merge

3. deprecate-router-events
-   https://deprecations.emberjs.com/v3.x/#toc_deprecate-router-events

4. object-new-constructor
-   https://deprecations.emberjs.com/v3.x/#toc_object-new-constructor
