### PR TITLE
INT-2048 chore: replace repomod-api with filemod, fix TS and ESLint errors

### DIFF
--- a/cal.com/app-directory-boilerplate-calcom/index.ts
+++ b/cal.com/app-directory-boilerplate-calcom/index.ts
@@ -1,11 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { join, posix } from 'node:path';
 import tsmorph, { SyntaxKind } from 'ts-morph';
-import type {
-	HandleData,
-	HandleFile,
-	Repomod,
-} from '@intuita-inc/repomod-engine-api';
+import type { HandleData, HandleFile, Filemod } from '@intuita-inc/filemod';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type Dependencies = Readonly<{
@@ -229,7 +225,7 @@ const buildPageFileData = (
 	};
 };
 
-const handleFile: Repomod<
+const handleFile: Filemod<
 	Dependencies,
 	Record<string, never>
 >['handleFile'] = async (api, path, options) => {
@@ -402,7 +398,7 @@ const handleData: HandleData<Dependencies, State> = async (
 	}
 };
 
-export const repomod: Repomod<Dependencies, State> = {
+export const repomod: Filemod<Dependencies, State> = {
 	includePatterns: ['**/pages/**/*.{js,jsx,ts,tsx}'],
 	excludePatterns: ['**/node_modules/**', '**/pages/api/**'],
 	handleFile,

--- a/cal.com/app-directory-boilerplate-calcom/test.ts
+++ b/cal.com/app-directory-boilerplate-calcom/test.ts
@@ -5,8 +5,8 @@ import {
 	FileSystemManager,
 	UnifiedFileSystem,
 	buildApi,
-	executeRepomod,
-} from '@intuita-inc/repomod-engine-api';
+	executeFilemod,
+} from '@intuita-inc/filemod';
 import { LAYOUT_CONTENT, repomod } from './index.js';
 import tsmorph from 'ts-morph';
 
@@ -14,12 +14,14 @@ const transform = async (json: DirectoryJSON) => {
 	const volume = Volume.fromJSON(json);
 
 	const fileSystemManager = new FileSystemManager(
-		volume.promises.readdir as any,
-		volume.promises.readFile as any,
-		volume.promises.stat as any,
+		// @ts-expect-error type convergence
+		volume.promises.readdir,
+		volume.promises.readFile,
+		volume.promises.stat,
 	);
 	const unifiedFileSystem = new UnifiedFileSystem(
-		createFsFromVolume(volume) as any,
+		// @ts-expect-error type convergence
+		createFsFromVolume(volume),
 		fileSystemManager,
 	);
 
@@ -29,7 +31,7 @@ const transform = async (json: DirectoryJSON) => {
 		tsmorph,
 	}));
 
-	return executeRepomod(api, repomod, '/', {}, {});
+	return executeFilemod(api, repomod, '/', {}, {});
 };
 
 describe('cal.com app-directory-boilerplate-calcom', function () {

--- a/cal.com/generate-metadata-tests-calcom/index.ts
+++ b/cal.com/generate-metadata-tests-calcom/index.ts
@@ -1,8 +1,4 @@
-import {
-	Repomod,
-	HandleData,
-	HandleFile,
-} from '@intuita-inc/repomod-engine-api';
+import { Filemod, HandleData, HandleFile } from '@intuita-inc/filemod';
 import { posix } from 'node:path';
 
 export const buildData = (appPath: string) => `
@@ -83,7 +79,7 @@ type State = {
 	testPath: string | null;
 };
 
-const initializeState: Repomod<Dependencies, State>['initializeState'] = async (
+const initializeState: Filemod<Dependencies, State>['initializeState'] = async (
 	options,
 ) => ({
 	testPath: typeof options.testPath === 'string' ? options.testPath : null,
@@ -157,7 +153,7 @@ const handleData: HandleData<Dependencies, State> = async (
 	};
 };
 
-export const repomod: Repomod<Dependencies, State> = {
+export const repomod: Filemod<Dependencies, State> = {
 	includePatterns: ['**/pages/**/*.{js,jsx,ts,tsx}'],
 	excludePatterns: ['**/node_modules/**', '**/pages/api/**'],
 	initializeState,

--- a/cal.com/generate-metadata-tests-calcom/test.ts
+++ b/cal.com/generate-metadata-tests-calcom/test.ts
@@ -5,26 +5,28 @@ import {
 	FileSystemManager,
 	UnifiedFileSystem,
 	buildApi,
-	executeRepomod,
-} from '@intuita-inc/repomod-engine-api';
+	executeFilemod,
+} from '@intuita-inc/filemod';
 import { buildData, repomod } from './index.js';
 
 const transform = async (json: DirectoryJSON) => {
 	const volume = Volume.fromJSON(json);
 
 	const fileSystemManager = new FileSystemManager(
-		volume.promises.readdir as any,
-		volume.promises.readFile as any,
-		volume.promises.stat as any,
+		// @ts-expect-error type convergence
+		volume.promises.readdir,
+		volume.promises.readFile,
+		volume.promises.stat,
 	);
 	const unifiedFileSystem = new UnifiedFileSystem(
-		createFsFromVolume(volume) as any,
+		// @ts-expect-error type convergence
+		createFsFromVolume(volume),
 		fileSystemManager,
 	);
 
 	const api = buildApi<Record<string, never>>(unifiedFileSystem, () => ({}));
 
-	return executeRepomod(api, repomod, '/', { testPath: '/opt/tests' }, {});
+	return executeFilemod(api, repomod, '/', { testPath: '/opt/tests' }, {});
 };
 
 type ExternalFileCommand = Awaited<ReturnType<typeof transform>>[number];

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -10,10 +10,7 @@ import tsmorph, {
 	JsxSelfClosingElement,
 } from 'ts-morph';
 
-import type {
-	Repomod,
-	UnifiedFileSystem,
-} from '@intuita-inc/repomod-engine-api';
+import type { Filemod, UnifiedFileSystem } from '@intuita-inc/filemod';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type Dependencies = Readonly<{
@@ -340,7 +337,7 @@ type State = {
 	translationsCollected: boolean;
 };
 
-export const repomod: Repomod<Dependencies, State> = {
+export const repomod: Filemod<Dependencies, State> = {
 	includePatterns: ['**/*.{js,jsx,ts,tsx,cjs,mjs,json}'],
 	excludePatterns: ['**/node_modules/**'],
 	initializeState: async (_, previousState) => {

--- a/i18n/test.ts
+++ b/i18n/test.ts
@@ -4,8 +4,8 @@ import {
 	FileSystemManager,
 	UnifiedFileSystem,
 	buildApi,
-	executeRepomod,
-} from '@intuita-inc/repomod-engine-api';
+	executeFilemod,
+} from '@intuita-inc/filemod';
 import { repomod } from './index.js';
 import tsmorph from 'ts-morph';
 import { deepStrictEqual } from 'node:assert';
@@ -34,7 +34,7 @@ const transform = async (json: DirectoryJSON) => {
 		unifiedFileSystem,
 	}));
 
-	return executeRepomod(api, repomod, '/', {}, {});
+	return executeFilemod(api, repomod, '/', {}, {});
 };
 
 describe('i18n remove unused translations', function () {

--- a/netlify-sdk/0.8.4/addApiHandler/index.ts
+++ b/netlify-sdk/0.8.4/addApiHandler/index.ts
@@ -17,7 +17,13 @@ export default function transform(
 		},
 	}).replaceWith((path) => {
 		// Replace addHandler with addApiHandler
-		path.node.callee.property.name = 'addApiHandler';
+		if (
+			'property' in path.node.callee &&
+			'name' in path.node.callee.property
+		) {
+			path.node.callee.property.name = 'addApiHandler';
+		}
+
 		return path.node;
 	});
 

--- a/next-i18next/copy-keys/index.ts
+++ b/next-i18next/copy-keys/index.ts
@@ -1,4 +1,4 @@
-import { Repomod } from '@intuita-inc/repomod-engine-api';
+import { Filemod } from '@intuita-inc/filemod';
 
 type Dependencies = Record<string, never>;
 type State = {
@@ -8,7 +8,7 @@ type State = {
 	map: Map<string, string>;
 };
 
-export const repomod: Repomod<Dependencies, State> = {
+export const repomod: Filemod<Dependencies, State> = {
 	includePatterns: ['**/locales/**/*.json'],
 	excludePatterns: ['**/node_modules/**'],
 	initializeState: async (options) => {

--- a/next-i18next/copy-keys/test.ts
+++ b/next-i18next/copy-keys/test.ts
@@ -4,8 +4,8 @@ import {
 	FileSystemManager,
 	UnifiedFileSystem,
 	buildApi,
-	executeRepomod,
-} from '@intuita-inc/repomod-engine-api';
+	executeFilemod,
+} from '@intuita-inc/filemod';
 import { repomod } from './index.js';
 import { deepStrictEqual } from 'node:assert';
 
@@ -29,7 +29,7 @@ const transform = async (json: DirectoryJSON, options: Options) => {
 
 	const api = buildApi<Record<string, never>>(unifiedFileSystem, () => ({}));
 
-	return executeRepomod(api, repomod, '/', options, {});
+	return executeFilemod(api, repomod, '/', options, {});
 };
 
 describe('next-i18n copy keys', function () {

--- a/next/13/app-directory-boilerplate/index.ts
+++ b/next/13/app-directory-boilerplate/index.ts
@@ -11,11 +11,7 @@ import tsmorph, {
 	SyntaxKind,
 	FunctionExpression,
 } from 'ts-morph';
-import type {
-	HandleData,
-	HandleFile,
-	Repomod,
-} from '@intuita-inc/repomod-engine-api';
+import type { HandleData, HandleFile, Filemod } from '@intuita-inc/filemod';
 import type { fromMarkdown } from 'mdast-util-from-markdown';
 import type { visit } from 'unist-util-visit';
 
@@ -714,7 +710,7 @@ const injectLayoutClientComponent = (sourceFile: SourceFile) => {
 	);
 };
 
-const handleFile: Repomod<
+const handleFile: Filemod<
 	Dependencies,
 	Record<string, never>
 >['handleFile'] = async (api, path, options) => {
@@ -1076,7 +1072,7 @@ const handleData: HandleData<Dependencies, State> = async (
 	}
 };
 
-export const repomod: Repomod<Dependencies, State> = {
+export const repomod: Filemod<Dependencies, State> = {
 	includePatterns: ['**/pages/**/*.{js,jsx,ts,tsx,cjs,mjs,mdx}'],
 	excludePatterns: ['**/node_modules/**', '**/pages/api/**'],
 	handleFile,

--- a/next/13/app-directory-boilerplate/test.ts
+++ b/next/13/app-directory-boilerplate/test.ts
@@ -5,8 +5,8 @@ import {
 	FileSystemManager,
 	UnifiedFileSystem,
 	buildApi,
-	executeRepomod,
-} from '@intuita-inc/repomod-engine-api';
+	executeFilemod,
+} from '@intuita-inc/filemod';
 import { repomod } from './index.js';
 import tsmorph from 'ts-morph';
 import { fromMarkdown } from 'mdast-util-from-markdown';
@@ -81,7 +81,7 @@ const transform = async (json: DirectoryJSON) => {
 		visitMdxAst: visit,
 	}));
 
-	return executeRepomod(api, repomod, '/', {}, {});
+	return executeFilemod(api, repomod, '/', {}, {});
 };
 
 describe('next 13 app-directory-boilerplate', function () {

--- a/next/13/remove-next-export/index.ts
+++ b/next/13/remove-next-export/index.ts
@@ -1,13 +1,13 @@
 import { posix } from 'node:path';
 import tsmorph from 'ts-morph';
-import type { Repomod } from '@intuita-inc/repomod-engine-api';
+import type { Filemod } from '@intuita-inc/filemod';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type Dependencies = Readonly<{
 	tsmorph: typeof tsmorph;
 }>;
 
-export const repomod: Repomod<Dependencies, Record<string, unknown>> = {
+export const repomod: Filemod<Dependencies, Record<string, unknown>> = {
 	includePatterns: ['**/package.json', '**/next.config.js', '**/*.{md,sh}'],
 	excludePatterns: ['**/node_modules/**'],
 	handleData: async (api, path, data) => {

--- a/next/13/remove-next-export/test.ts
+++ b/next/13/remove-next-export/test.ts
@@ -2,8 +2,8 @@ import {
 	FileSystemManager,
 	UnifiedFileSystem,
 	buildApi,
-	executeRepomod,
-} from '@intuita-inc/repomod-engine-api';
+	executeFilemod,
+} from '@intuita-inc/filemod';
 import { Volume, createFsFromVolume } from 'memfs';
 import tsmorph from 'ts-morph';
 import { repomod } from './index.js';
@@ -68,7 +68,7 @@ const transform = async () => {
 		tsmorph,
 	}));
 
-	return executeRepomod(api, repomod, '/', {}, {});
+	return executeFilemod(api, repomod, '/', {}, {});
 };
 
 describe('next 13 remove-next-export', function () {

--- a/next/13/replace-api-routes/index.ts
+++ b/next/13/replace-api-routes/index.ts
@@ -9,10 +9,7 @@ import tsmorph, {
 	Block,
 } from 'ts-morph';
 
-import type {
-	Repomod,
-	UnifiedFileSystem,
-} from '@intuita-inc/repomod-engine-api';
+import type { Filemod, UnifiedFileSystem } from '@intuita-inc/filemod';
 
 import { posix } from 'node:path';
 import { ParsedPath } from 'path/posix';
@@ -349,7 +346,7 @@ const rewriteAPIRoute = (sourceFile: SourceFile) => {
 	rewriteReqResImports(sourceFile);
 };
 
-export const repomod: Repomod<Dependencies, Record<string, unknown>> = {
+export const repomod: Filemod<Dependencies, Record<string, unknown>> = {
 	includePatterns: ['**/pages/api/**/*.{js,ts,cjs,ejs}'],
 	excludePatterns: ['**/node_modules/**'],
 	handleFile: async (api, path) => {

--- a/next/13/replace-api-routes/test.ts
+++ b/next/13/replace-api-routes/test.ts
@@ -4,8 +4,8 @@ import {
 	FileSystemManager,
 	UnifiedFileSystem,
 	buildApi,
-	executeRepomod,
-} from '@intuita-inc/repomod-engine-api';
+	executeFilemod,
+} from '@intuita-inc/filemod';
 import { repomod } from './index.js';
 import tsmorph from 'ts-morph';
 import { deepStrictEqual } from 'node:assert';
@@ -34,7 +34,7 @@ const transform = async (json: DirectoryJSON) => {
 		unifiedFileSystem,
 	}));
 
-	return executeRepomod(api, repomod, '/', {}, {});
+	return executeFilemod(api, repomod, '/', {}, {});
 };
 
 describe('next 13 replace-API-routes', function () {

--- a/next/13/replace-next-head/index.ts
+++ b/next/13/replace-next-head/index.ts
@@ -17,10 +17,7 @@ import tsmorph, {
 	FunctionDeclaration,
 } from 'ts-morph';
 
-import type {
-	Repomod,
-	UnifiedFileSystem,
-} from '@intuita-inc/repomod-engine-api';
+import type { Filemod, UnifiedFileSystem } from '@intuita-inc/filemod';
 import type { fromMarkdown } from 'mdast-util-from-markdown';
 import type { visit } from 'unist-util-visit';
 import type { filter } from 'unist-util-filter';
@@ -1027,7 +1024,7 @@ type MetadataTreeNode = {
 };
 
 type FileAPI = Parameters<
-	NonNullable<Repomod<Dependencies, State>['handleFile']>
+	NonNullable<Filemod<Dependencies, State>['handleFile']>
 >[0];
 
 export const projectContainer = buildContainer<tsmorph.Project | null>(null);
@@ -1724,7 +1721,7 @@ const getTsCompilerOptions = async (api: FileAPI, baseUrl: string) => {
 	}
 };
 
-export const repomod: Repomod<Dependencies, Record<string, unknown>> = {
+export const repomod: Filemod<Dependencies, Record<string, unknown>> = {
 	includePatterns: ['**/pages/**/*.{jsx,tsx,js,ts,cjs,ejs,mdx}'],
 	excludePatterns: ['**/node_modules/**', '**/pages/api/**'],
 	handleFile: async (api, path, options) => {

--- a/next/13/replace-next-head/test.ts
+++ b/next/13/replace-next-head/test.ts
@@ -4,8 +4,8 @@ import {
 	FileSystemManager,
 	UnifiedFileSystem,
 	buildApi,
-	executeRepomod,
-} from '@intuita-inc/repomod-engine-api';
+	executeFilemod,
+} from '@intuita-inc/filemod';
 import { repomod, projectContainer, subTreeCacheContainer } from './index.js';
 import tsmorph from 'ts-morph';
 import { fromMarkdown } from 'mdast-util-from-markdown';
@@ -59,7 +59,7 @@ const transform = async (json: DirectoryJSON) => {
 		unifiedFileSystem,
 	}));
 
-	return executeRepomod(api, repomod, '/', {}, {});
+	return executeFilemod(api, repomod, '/', {}, {});
 };
 
 describe('next 13 replace-next-head', function () {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"@babel/core": ">=7.13.0 <8.0.0",
 		"@babel/preset-env": "^7.1.6",
 		"@effect/schema": "0.26.1",
-		"@intuita-inc/repomod-engine-api": "^1.2.1",
+		"@intuita-inc/filemod": "1.0.0",
 		"@types/chai": "^4.3.4",
 		"@types/jscodeshift": "^0.11.6",
 		"@types/mocha": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -14,9 +14,9 @@ devDependencies:
   '@effect/schema':
     specifier: 0.26.1
     version: 0.26.1
-  '@intuita-inc/repomod-engine-api':
-    specifier: ^1.2.1
-    version: 1.2.1
+  '@intuita-inc/filemod':
+    specifier: 1.0.0
+    version: 1.0.0
   '@types/chai':
     specifier: ^4.3.4
     version: 4.3.4
@@ -1451,10 +1451,10 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@intuita-inc/repomod-engine-api@1.2.1:
-    resolution: {integrity: sha512-Z0dksB/hgoyR1kPsQ+hrE5M6ww5/vmE6b5VvMmO3ceurs7Pu5xQfu1pi49INBPRuWh1OH1vEXBlsmyGQeQMHzw==}
+  /@intuita-inc/filemod@1.0.0:
+    resolution: {integrity: sha512-vbLJ9m4N2A+kVTp5bl3cj84g097gkm0LytfEx9FzdEc07YPIBEnRDHv6O02s1Wzl8+8FWrmKZSm+RO9XGc5zvw==}
     dependencies:
-      glob: 10.3.4
+      glob: 10.3.10
     dev: true
 
   /@isaacs/cliui@8.0.2:
@@ -3165,20 +3165,20 @@ packages:
       is-glob: 4.0.3
     dev: true
 
-  /glob@10.3.3:
-    resolution: {integrity: sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==}
+  /glob@10.3.10:
+    resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
     dependencies:
       foreground-child: 3.1.1
-      jackspeak: 2.2.1
+      jackspeak: 2.3.6
       minimatch: 9.0.3
       minipass: 6.0.2
       path-scurry: 1.10.1
     dev: true
 
-  /glob@10.3.4:
-    resolution: {integrity: sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==}
+  /glob@10.3.3:
+    resolution: {integrity: sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
     dependencies:
@@ -3624,6 +3624,15 @@ packages:
 
   /jackspeak@2.2.1:
     resolution: {integrity: sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+    dev: true
+
+  /jackspeak@2.3.6:
+    resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
     dependencies:
       '@isaacs/cliui': 8.0.2

--- a/remove-unused-feature-flags-2/index.ts
+++ b/remove-unused-feature-flags-2/index.ts
@@ -1,4 +1,4 @@
-import { Repomod } from '@intuita-inc/repomod-engine-api';
+import { Filemod } from '@intuita-inc/filemod';
 import jscodeshift from 'jscodeshift';
 
 type Dependencies = {
@@ -14,7 +14,7 @@ const FILE_MARKER = 'fileMarker';
 const FEATURE_FLAG_NAME = 'featureFlagName';
 const FUNCTION_NAME = 'functionName';
 
-export const repomod: Repomod<Dependencies, State> = {
+export const repomod: Filemod<Dependencies, State> = {
 	includePatterns: ['**/*.{js,jsx,ts,tsx,cjs,mjs}'],
 	excludePatterns: ['**/node_modules/**'],
 	initializeState: async (_, previousState) => {

--- a/remove-unused-feature-flags-2/test.ts
+++ b/remove-unused-feature-flags-2/test.ts
@@ -2,8 +2,8 @@ import {
 	FileSystemManager,
 	UnifiedFileSystem,
 	buildApi,
-	executeRepomod,
-} from '@intuita-inc/repomod-engine-api';
+	executeFilemod,
+} from '@intuita-inc/filemod';
 import jscodeshift from 'jscodeshift';
 import { DirectoryJSON, Volume, createFsFromVolume } from 'memfs';
 import { repomod } from './index.js';
@@ -29,7 +29,7 @@ const transform = async (json: DirectoryJSON) => {
 		jscodeshift,
 	}));
 
-	return executeRepomod(
+	return executeFilemod(
 		api,
 		repomod,
 		'/',


### PR DESCRIPTION
We did not change the codemod configuration files for compability reasons.
The only changes are in terms of types and tests.