### PR TITLE
INT-2073 Update App router boilerplate for cal.com

### DIFF
--- a/cal.com/app-directory-boilerplate-calcom/index.ts
+++ b/cal.com/app-directory-boilerplate-calcom/index.ts
@@ -42,10 +42,7 @@ const addUseClientStatement = (
 		},
 	});
 
-	const sourceFile = project.createSourceFile(
-		oldPath?.replace(/\.mdx$/, '.tsx') ?? '',
-		oldData,
-	);
+	const sourceFile = project.createSourceFile(oldPath ?? '', oldData);
 
 	const hasUseClient = sourceFile
 		.getDescendantsOfKind(SyntaxKind.StringLiteral)
@@ -85,10 +82,7 @@ const buildPageFileData = (
 		const oldPath =
 			typeof options.oldPath === 'string' ? options.oldPath : null;
 
-		const sourceFile = project.createSourceFile(
-			oldPath?.replace(/\.mdx$/, '.tsx') ?? '',
-			input,
-		);
+		const sourceFile = project.createSourceFile(oldPath ?? '', input);
 
 		sourceFile.getFunctions().forEach((fn) => {
 			if (fn.isDefaultExport()) {
@@ -221,10 +215,7 @@ const handleFile: Filemod<
 			},
 		});
 
-		const sourceFile = project.createSourceFile(
-			path?.replace(/\.mdx$/, '.tsx') ?? '',
-			oldData,
-		);
+		const sourceFile = project.createSourceFile(path ?? '', oldData);
 
 		const notNeedLayout = sourceFile
 			.getDescendantsOfKind(SyntaxKind.JsxOpeningElement)
@@ -260,7 +251,7 @@ export default Page;`;
 				path: posix.format({
 					root: parsedPath.root,
 					dir: newDir,
-					ext: parsedPath.ext === '.mdx' ? '.mdx' : '.tsx',
+					ext: parsedPath.ext,
 					name: 'page',
 				}),
 				options: {
@@ -275,7 +266,7 @@ export default Page;`;
 				path: posix.format({
 					root: parsedPath.root,
 					dir: parsedPath.dir,
-					ext: parsedPath.ext === '.mdx' ? '.mdx' : '.tsx',
+					ext: parsedPath.ext,
 					name: parsedPath.name,
 				}),
 				options: {

--- a/cal.com/app-directory-boilerplate-calcom/test.ts
+++ b/cal.com/app-directory-boilerplate-calcom/test.ts
@@ -37,7 +37,7 @@ const transform = async (json: DirectoryJSON) => {
 describe('cal.com app-directory-boilerplate-calcom', function () {
 	it('should build correct files', async function (this: Context) {
 		const externalFileCommands = await transform({
-			'/opt/project/pages/a/index.tsx': 'TODO content', // root page
+			'/opt/project/pages/a/index.tsx': 'TODO content',
 			'/opt/project/pages/a/b.tsx': `
 			export default function B(props) {
 				return <Shell isPublic title='1'>Shell</Shell>
@@ -48,9 +48,10 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 				return <Shell  subtitle='1'>Shell</Shell>
 			}
 			`,
+			'/opt/project/pages/a/d.tsx': 'TODO content',
 		});
 
-		deepStrictEqual(externalFileCommands.length, 6);
+		deepStrictEqual(externalFileCommands.length, 8);
 
 		ok(
 			externalFileCommands.some(
@@ -100,6 +101,23 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 				(command) =>
 					command.kind === 'upsertFile' &&
 					command.path === '/opt/project/pages/a/[b]/c.tsx',
+			),
+		);
+
+		ok(
+			externalFileCommands.some(
+				(command) =>
+					command.kind === 'upsertFile' &&
+					command.path ===
+						'/opt/project/app/future/(layout)/a/d/page.tsx',
+			),
+		);
+
+		ok(
+			externalFileCommands.some(
+				(command) =>
+					command.kind === 'upsertFile' &&
+					command.path === '/opt/project/pages/a/d.tsx',
 			),
 		);
 
@@ -192,6 +210,36 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 						export default function C(props) {
 							return <Shell  subtitle='1'>Shell</Shell>
 						}
+						`.replace(/\W/gm, '')
+				);
+			}),
+		);
+
+		ok(
+			externalFileCommands.some((command) => {
+				return (
+					command.kind === 'upsertFile' &&
+					command.path ===
+						'/opt/project/app/future/(layout)/a/d/page.tsx' &&
+					command.data.replace(/\W/gm, '') ===
+						`
+						import Page from "@pages/a/d";
+						// TODO add metadata
+						export default Page;
+					`.replace(/\W/gm, '')
+				);
+			}),
+		);
+
+		ok(
+			externalFileCommands.some((command) => {
+				return (
+					command.kind === 'upsertFile' &&
+					command.path === '/opt/project/pages/a/d.tsx' &&
+					command.data.replace(/\W/gm, '') ===
+						`
+						'use client';
+						TODO content
 						`.replace(/\W/gm, '')
 				);
 			}),

--- a/cal.com/app-directory-boilerplate-calcom/test.ts
+++ b/cal.com/app-directory-boilerplate-calcom/test.ts
@@ -7,7 +7,7 @@ import {
 	buildApi,
 	executeFilemod,
 } from '@intuita-inc/filemod';
-import { LAYOUT_CONTENT, repomod } from './index.js';
+import { repomod } from './index.js';
 import tsmorph from 'ts-morph';
 
 const transform = async (json: DirectoryJSON) => {
@@ -37,26 +37,27 @@ const transform = async (json: DirectoryJSON) => {
 describe('cal.com app-directory-boilerplate-calcom', function () {
 	it('should build correct files', async function (this: Context) {
 		const externalFileCommands = await transform({
-			'/opt/project/pages/a/index.tsx': 'TODO content',
-			'/opt/project/pages/a/b.tsx': 'TODO content',
-			'/opt/project/pages/a/[b]/c.tsx': 'TODO content',
+			'/opt/project/pages/a/index.tsx': 'TODO content', // root page
+			'/opt/project/pages/a/b.tsx': `
+			export default function B(props) {
+				return <Shell isPublic title='1'>Shell</Shell>
+			}
+			`,
+			'/opt/project/pages/a/[b]/c.tsx': `
+			export default function C(props) {
+				return <Shell  subtitle='1'>Shell</Shell>
+			}
+			`,
 		});
 
-		deepStrictEqual(externalFileCommands.length, 9);
+		deepStrictEqual(externalFileCommands.length, 6);
 
 		ok(
 			externalFileCommands.some(
 				(command) =>
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/page.tsx',
-			),
-		);
-
-		ok(
-			externalFileCommands.some(
-				(command) =>
-					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/layout.tsx',
+					command.path ===
+						'/opt/project/app/future/(layout)/a/page.tsx',
 			),
 		);
 
@@ -72,15 +73,8 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 			externalFileCommands.some(
 				(command) =>
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/b/page.tsx',
-			),
-		);
-
-		ok(
-			externalFileCommands.some(
-				(command) =>
-					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/b/layout.tsx',
+					command.path ===
+						'/opt/project/app/future/(no-layout)/a/b/page.tsx',
 			),
 		);
 
@@ -96,15 +90,8 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 			externalFileCommands.some(
 				(command) =>
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/[b]/c/page.tsx',
-			),
-		);
-
-		ok(
-			externalFileCommands.some(
-				(command) =>
-					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/[b]/c/layout.tsx',
+					command.path ===
+						'/opt/project/app/future/(no-layout)/a/[b]/c/page.tsx',
 			),
 		);
 
@@ -120,24 +107,14 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/page.tsx' &&
+					command.path ===
+						'/opt/project/app/future/(layout)/a/page.tsx' &&
 					command.data.replace(/\W/gm, '') ===
 						`
 						import Page from "@pages/a/index";
 						// TODO add metadata
 						export default Page;
 					`.replace(/\W/gm, '')
-				);
-			}),
-		);
-
-		ok(
-			externalFileCommands.some((command) => {
-				return (
-					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/layout.tsx' &&
-					command.data.replace(/\W/gm, '') ===
-						LAYOUT_CONTENT.replace(/\W/gm, '')
 				);
 			}),
 		);
@@ -160,7 +137,8 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/b/page.tsx' &&
+					command.path ===
+						'/opt/project/app/future/(no-layout)/a/b/page.tsx' &&
 					command.data.replace(/\W/gm, '') ===
 						`
 						import Page from "@pages/a/b";
@@ -175,22 +153,13 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/b/layout.tsx' &&
-					command.data.replace(/\W/gm, '') ===
-						LAYOUT_CONTENT.replace(/\W/gm, '')
-				);
-			}),
-		);
-
-		ok(
-			externalFileCommands.some((command) => {
-				return (
-					command.kind === 'upsertFile' &&
 					command.path === '/opt/project/pages/a/b.tsx' &&
 					command.data.replace(/\W/gm, '') ===
 						`
 						'use client';
-						TODO content
+						export default function B(props) {
+							return <Shell isPublic title='1'>Shell</Shell>
+						}
 						`.replace(/\W/gm, '')
 				);
 			}),
@@ -200,7 +169,8 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/[b]/c/page.tsx' &&
+					command.path ===
+						'/opt/project/app/future/(no-layout)/a/[b]/c/page.tsx' &&
 					command.data.replace(/\W/gm, '') ===
 						`
 						import Page from "@pages/a/[b]/c";
@@ -215,22 +185,13 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/app/a/[b]/c/layout.tsx' &&
-					command.data.replace(/\W/gm, '') ===
-						LAYOUT_CONTENT.replace(/\W/gm, '')
-				);
-			}),
-		);
-
-		ok(
-			externalFileCommands.some((command) => {
-				return (
-					command.kind === 'upsertFile' &&
 					command.path === '/opt/project/pages/a/[b]/c.tsx' &&
 					command.data.replace(/\W/gm, '') ===
 						`
 						'use client';
-						TODO content
+						export default function C(props) {
+							return <Shell  subtitle='1'>Shell</Shell>
+						}
 						`.replace(/\W/gm, '')
 				);
 			}),


### PR DESCRIPTION
https://linear.app/intuita/issue/INT-2073/update-app-router-boilerplate-for-calcom

### Motivation
- structural changes in app directory
- app directory contains (layout) folder and (no-layout) folder, in each of which layout.tsx file exists
- most pages (e.g., /availability/index.tsx) should go under (layout) folder while some pages that already contain layout (e.g., /availability/[schedule].tsx) should go under (no-layout)folder.