### PR TITLE
INT-2153 Remove from calcom boilerplate additions of use client statement

### DIFF
--- a/cal.com/app-directory-boilerplate-calcom/index.ts
+++ b/cal.com/app-directory-boilerplate-calcom/index.ts
@@ -30,38 +30,6 @@ type DataAPI = Parameters<HandleData<Dependencies, State>>[0];
 type FileCommand = Awaited<ReturnType<HandleFile<Dependencies, State>>>[number];
 type DataCommand = Awaited<ReturnType<HandleData<Dependencies, State>>>;
 
-const addUseClientStatement = (
-	oldPath: string,
-	oldData: string,
-): DataCommand => {
-	const project = new tsmorph.Project({
-		useInMemoryFileSystem: true,
-		skipFileDependencyResolution: true,
-		compilerOptions: {
-			allowJs: true,
-		},
-	});
-
-	const sourceFile = project.createSourceFile(oldPath ?? '', oldData);
-
-	const hasUseClient = sourceFile
-		.getDescendantsOfKind(SyntaxKind.StringLiteral)
-		.some((node) => {
-			const literal = node.getFullText();
-			return literal === 'use client';
-		});
-
-	if (!hasUseClient) {
-		sourceFile.insertStatements(0, `'use client';`);
-	}
-
-	return {
-		kind: 'upsertData',
-		path: oldPath,
-		data: sourceFile.getFullText(),
-	};
-};
-
 const ROUTE_SEGMENT_CONFIG_OPTIONS = [
 	'dynamic',
 	'dynamicParams',
@@ -650,17 +618,6 @@ const handleData: HandleData<Dependencies, State> = async (
 
 		if (filePurpose === FilePurpose.ROUTE_PAGE && options.oldPath) {
 			return buildPageFileData(api, path, options, filePurpose);
-		}
-
-		if (
-			filePurpose === FilePurpose.ORIGINAL_PAGE &&
-			options.oldPath &&
-			options.oldData
-		) {
-			return addUseClientStatement(
-				String(options.oldPath),
-				String(options.oldData),
-			);
 		}
 
 		return {

--- a/cal.com/app-directory-boilerplate-calcom/test.ts
+++ b/cal.com/app-directory-boilerplate-calcom/test.ts
@@ -159,20 +159,6 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/pages/a/index.tsx' &&
-					command.data.replace(/\W/gm, '') ===
-						`
-						'use client';
-						TODO content
-						`.replace(/\W/gm, '')
-				);
-			}),
-		);
-
-		ok(
-			externalFileCommands.some((command) => {
-				return (
-					command.kind === 'upsertFile' &&
 					command.path ===
 						'/opt/project/app/future/(shared-page-wrapper)/(layout)/a/b/page.tsx' &&
 					command.data.replace(/\W/gm, '') ===
@@ -183,24 +169,6 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 						export const generateMetadata = async () => await _generateMetadata(() => "", () => "");
 						export default Page;
 					`.replace(/\W/gm, '')
-				);
-			}),
-		);
-
-		ok(
-			externalFileCommands.some((command) => {
-				return (
-					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/pages/a/b.tsx' &&
-					command.data.replace(/\W/gm, '') ===
-						`
-						'use client';
-						import { getLayout } from './getLayout';
-						export default function B(props) {
-							return <Component />;
-						}
-						B.getLayout = getLayout;
-						`.replace(/\W/gm, '')
 				);
 			}),
 		);
@@ -249,25 +217,6 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 
 		ok(
 			externalFileCommands.some((command) => {
-				return (
-					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/pages/a/[b]/c.tsx' &&
-					command.data.replace(/\W/gm, '') ===
-						`
-						'use client';
-						export const getServerSideProps = (ctx) => {
-							return null;
-						}
-						export default function C(props) {
-							return <Component />;
-						}
-						`.replace(/\W/gm, '')
-				);
-			}),
-		);
-
-		ok(
-			externalFileCommands.some((command) => {
 				const expected = `
 					import OldPage from "@pages/a/d";
 					import { _generateMetadata } from "app/_utils";
@@ -303,25 +252,6 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 						'/opt/project/app/future/(individual-page-wrapper)/a/d/page.tsx' &&
 					command.data.replace(/\W/gm, '') ===
 						expected.replace(/\W/gm, '')
-				);
-			}),
-		);
-
-		ok(
-			externalFileCommands.some((command) => {
-				return (
-					command.kind === 'upsertFile' &&
-					command.path === '/opt/project/pages/a/d.tsx' &&
-					command.data.replace(/\W/gm, '') ===
-						`
-						'use client';
-						export const getStaticProps = (ctx) => {
-							return null;
-						}
-						export default function C(props) {
-							return <Component />;
-						}
-						`.replace(/\W/gm, '')
 				);
 			}),
 		);


### PR DESCRIPTION
if we are expecting people to `run remove-get-static-props` and then boilerplate codemod, we should remove the functionality of adding “use client” in boilerplate codemod
