### PR TITLE
INT-2161 Revert 'Remove from calcom boilerplate additions of use client statement'

### DIFF
--- a/cal.com/app-directory-boilerplate-calcom/test.ts
+++ b/cal.com/app-directory-boilerplate-calcom/test.ts
@@ -159,6 +159,20 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 			externalFileCommands.some((command) => {
 				return (
 					command.kind === 'upsertFile' &&
+					command.path === '/opt/project/pages/a/index.tsx' &&
+					command.data.replace(/\W/gm, '') ===
+						`
+						'use client';
+						TODO content
+						`.replace(/\W/gm, '')
+				);
+			}),
+		);
+
+		ok(
+			externalFileCommands.some((command) => {
+				return (
+					command.kind === 'upsertFile' &&
 					command.path ===
 						'/opt/project/app/future/(shared-page-wrapper)/(layout)/a/b/page.tsx' &&
 					command.data.replace(/\W/gm, '') ===
@@ -169,6 +183,24 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 						export const generateMetadata = async () => await _generateMetadata(() => "", () => "");
 						export default Page;
 					`.replace(/\W/gm, '')
+				);
+			}),
+		);
+
+		ok(
+			externalFileCommands.some((command) => {
+				return (
+					command.kind === 'upsertFile' &&
+					command.path === '/opt/project/pages/a/b.tsx' &&
+					command.data.replace(/\W/gm, '') ===
+						`
+						'use client';
+						import { getLayout } from './getLayout';
+						export default function B(props) {
+							return <Component />;
+						}
+						B.getLayout = getLayout;
+						`.replace(/\W/gm, '')
 				);
 			}),
 		);
@@ -217,6 +249,25 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 
 		ok(
 			externalFileCommands.some((command) => {
+				return (
+					command.kind === 'upsertFile' &&
+					command.path === '/opt/project/pages/a/[b]/c.tsx' &&
+					command.data.replace(/\W/gm, '') ===
+						`
+						'use client';
+						export const getServerSideProps = (ctx) => {
+							return null;
+						}
+						export default function C(props) {
+							return <Component />;
+						}
+						`.replace(/\W/gm, '')
+				);
+			}),
+		);
+
+		ok(
+			externalFileCommands.some((command) => {
 				const expected = `
 					import OldPage from "@pages/a/d";
 					import { _generateMetadata } from "app/_utils";
@@ -252,6 +303,25 @@ describe('cal.com app-directory-boilerplate-calcom', function () {
 						'/opt/project/app/future/(individual-page-wrapper)/a/d/page.tsx' &&
 					command.data.replace(/\W/gm, '') ===
 						expected.replace(/\W/gm, '')
+				);
+			}),
+		);
+
+		ok(
+			externalFileCommands.some((command) => {
+				return (
+					command.kind === 'upsertFile' &&
+					command.path === '/opt/project/pages/a/d.tsx' &&
+					command.data.replace(/\W/gm, '') ===
+						`
+						'use client';
+						export const getStaticProps = (ctx) => {
+							return null;
+						}
+						export default function C(props) {
+							return <Component />;
+						}
+						`.replace(/\W/gm, '')
 				);
 			}),
 		);


### PR DESCRIPTION
We decided in our team meeting today to add `use client` to legacy pages as part of app-directory-boilerplate codemod and remove this functionality from remove-get-static-props codemod