### PR TITLE
fix(turbo): correct turborepo configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
             - name: Install dependencies
               run: pnpm install
             - name: Build the CJS files
-              run: pnpm build:cjs
-            - name: Build the S3 files
               run: pnpm build
             - name: Upload to S3
               uses: jakejarvis/s3-sync-action@master

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"author": "Intuita",
 	"packageManager": "pnpm@8.9.0",
 	"scripts": {
-		"build": "turbo run build --no-daemon",
-		"build:homedir": "turbo run build:homedir --no-daemon",
+		"build": "turbo run build:cjs && pnpm build --filter @codemod-registry/builder",
+		"build:homedir": "turbo run build:cjs && pnpm build:homedir --filter @codemod-registry/builder",
 		"build:cjs": "turbo run build:cjs --no-daemon",
 		"create": "turbo run create",
 		"lint:eslint": "eslint --fix .",

--- a/turbo.json
+++ b/turbo.json
@@ -4,18 +4,8 @@
 		"build:cjs": {
 			"dependsOn": ["^build:cjs"],
 			"outputMode": "full",
-			"inputs": ["./codemod/**/*.ts", "./codemod/**/*.js"],
-			"outputs": ["./codemods/**/dist/index.cjs"]
-		},
-		"build": {
-			"dependsOn": ["^build"],
-			"inputs": ["./codemods/**/dist/index.cjs"],
-			"outputs": ["./builder/dist/**/*.*"]
-		},
-		"build:homedir": {
-			"dependsOn": ["^build:homedir"],
-			"inputs": ["./codemods/**/dist/index.cjs"],
-			"outputs": ["./builder/dist/**/*.*"]
+			"inputs": ["./src/**/*.ts", "./src/**/*.js"],
+			"outputs": ["./dist/index.cjs"]
 		},
 		"create": {
 			"dependsOn": ["^create"],


### PR DESCRIPTION
Glob patterns in turbo.json are relative. To make all other workspaces run build:cjs we can just add a chain to package.json. Other real options would be:
- to depend on each individual build task of each workspace, which would pollute turbo.json
- to add all 120 packages as topological devDependencies of builder package which would pollute its package.json

As per [documentation](https://turbo.build/repo/docs/core-concepts/caching/file-inputs#customizing-the-behavior):

> These glob patterns are relative to the workspace's path, so, for build inside of the website app, it would treat /apps/website/src/** as file inputs, and, for build inside of the utils workspace it would consider /packages/utils/src/** as file inputs.