### PR TITLE
INT-2323 Fix links in codemod README files

### DIFF
--- a/codemods/msw/2/upgrade-recipe/README.md
+++ b/codemods/msw/2/upgrade-recipe/README.md
@@ -6,15 +6,15 @@ This recipe is a set of codemods that will upgrade your project from using msw v
 
 The recipe includes the following codemods:
 
--   [imports](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2/imports)
--   [type-args](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2/type-args)
--   [request-changes](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2/request-changes)
--   [ctx-fetch](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2/ctx-fetch)
--   [req-passthrough](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2/req-passthrough)
--   [response-usages](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2/response-usages)
--   [callback-signature](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2/callback-signature)
--   [lifecycle-events-signature](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2/lifecycle-events-signature)
--   [print-handler](https://github.com/intuita-inc/codemod-registry/tree/main/msw/2/print-handler)
+-   [imports](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/msw/2/imports)
+-   [type-args](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/msw/2/type-args)
+-   [request-changes](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/msw/2/request-changes)
+-   [ctx-fetch](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/msw/2/ctx-fetch)
+-   [req-passthrough](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/msw/2/req-passthrough)
+-   [response-usages](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/msw/2/response-usages)
+-   [callback-signature](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/msw/2/callback-signature)
+-   [lifecycle-events-signature](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/msw/2/lifecycle-events-signature)
+-   [print-handler](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/msw/2/print-handler)
 
 ### FNs
 This recipe does not change the signatures of MSW handlers, if they were called using a custom factory function, for example to provide more type-safety or else. For example, the following code will only be partially updated:

--- a/codemods/netlify-sdk/0.8.5/netlify-sdk-0.8.5-recipe/README.md
+++ b/codemods/netlify-sdk/0.8.5/netlify-sdk-0.8.5-recipe/README.md
@@ -6,14 +6,14 @@ The SDK v0.8.5 Recipe is a set of codemods that assist you with migrating to Net
 
 The recipe includes the following codemods:
 
--   [createEnvironmentVariable](https://github.com/intuita-inc/codemod-registry/tree/main/netlify-sdk/0.8.5/createEnvironmentVariable)
--   [createOrUpdateVariable](https://github.com/intuita-inc/codemod-registry/tree/main/netlify-sdk/0.8.5/createOrUpdateVariable)
--   [createOrUpdateVariables](https://github.com/intuita-inc/codemod-registry/tree/main/netlify-sdk/0.8.5/createOrUpdateVariables)
--   [deleteEnvironmentVariable](https://github.com/intuita-inc/codemod-registry/tree/main/netlify-sdk/0.8.5/deleteEnvironmentVariable)
--   [deleteEnvironmentVariables](https://github.com/intuita-inc/codemod-registry/tree/main/netlify-sdk/0.8.5/deleteEnvironmentVariables)
--   [getEnvironmentVariables](https://github.com/intuita-inc/codemod-registry/tree/main/netlify-sdk/0.8.5/getEnvironmentVariables)
--   [patchEnvironmentVariable](https://github.com/intuita-inc/codemod-registry/tree/main/netlify-sdk/0.8.5/patchEnvironmentVariable)
--   [updateEnvironmentVariable](https://github.com/intuita-inc/codemod-registry/tree/main/netlify-sdk/0.8.5/updateEnvironmentVariable)
+-   [createEnvironmentVariable](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/netlify-sdk/0.8.5/createEnvironmentVariable)
+-   [createOrUpdateVariable](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/netlify-sdk/0.8.5/createOrUpdateVariable)
+-   [createOrUpdateVariables](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/netlify-sdk/0.8.5/createOrUpdateVariables)
+-   [deleteEnvironmentVariable](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/netlify-sdk/0.8.5/deleteEnvironmentVariable)
+-   [deleteEnvironmentVariables](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/netlify-sdk/0.8.5/deleteEnvironmentVariables)
+-   [getEnvironmentVariables](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/netlify-sdk/0.8.5/getEnvironmentVariables)
+-   [patchEnvironmentVariable](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/netlify-sdk/0.8.5/patchEnvironmentVariable)
+-   [updateEnvironmentVariable](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/netlify-sdk/0.8.5/updateEnvironmentVariable)
 
 ## Applicability Criteria
 

--- a/codemods/next/13/app-router-recipe/README.md
+++ b/codemods/next/13/app-router-recipe/README.md
@@ -6,10 +6,10 @@ The App Router Recipe is a set of codemods that assist you with the pages-to-app
 
 The recipe includes the following codemods:
 
--   [replace-next-router](https://github.com/intuita-inc/codemod-registry/tree/main/next/13/replace-next-router)
--   [replace-next-head](https://github.com/intuita-inc/codemod-registry/tree/main/next/13/replace-next-head)
--   [remove-get-static-props](https://github.com/intuita-inc/codemod-registry/tree/main/next/13/remove-get-static-props)
--   [app-directory-boilerplate](https://github.com/intuita-inc/codemod-registry/tree/main/next/13/app-directory-boilerplate)
+-   [replace-next-router](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/next/13/replace-next-router)
+-   [replace-next-head](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/next/13/replace-next-head)
+-   [remove-get-static-props](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/next/13/remove-get-static-props)
+-   [app-directory-boilerplate](https://github.com/intuita-inc/codemod-registry/tree/main/codemods/next/13/app-directory-boilerplate)
 
 ## Applicability Criteria
 


### PR DESCRIPTION
we changed folder structure of codemod-registry repo but we never changed the links (to codemod-registry files in Github) in README.